### PR TITLE
add filter key to types

### DIFF
--- a/types/fuzzaldrin-plus-fast.d.ts
+++ b/types/fuzzaldrin-plus-fast.d.ts
@@ -23,8 +23,8 @@ export interface IOptions {
 
 export type IFilterOptions<T> = IOptions & {
 
-    // TODO not implemented?
-    // key?: T extends string ? never : keyof T
+    /** The key to use when candidates is an object */
+    key?: T extends string ? never : keyof T
 
     /** The maximum numbers of results to return */
     maxResults?: number


### PR DESCRIPTION
`key` is already implemented in setCandidates it just needed to be added to IFilterOptions

https://github.com/atom-ide-community/fuzzaldrin-plus-fast/blob/7199a7daa86ffba7f08ca360ff23fb7966641e47/fuzzaldrin.js#L26-L27

fixes #30