### PR TITLE
Clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks:          '*, -cppcoreguidelines-init-variables, -modernize-return-braced-init-list, -misc-unused-parameters, -misc-non-private-member-variables-in-classes, -llvmlibc-*, -llvm-header-guard, -llvm-include-order, -modernize-use-trailing-return-type, -readability-convert-member-functions-to-static, -fuchsia-default-arguments-declarations'
+HeaderFilterRegex: '.*'
+FormatStyle:     none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 ---
-Checks:          '*, -cppcoreguidelines-init-variables, -modernize-return-braced-init-list, -misc-unused-parameters, -misc-non-private-member-variables-in-classes, -llvmlibc-*, -llvm-header-guard, -llvm-include-order, -modernize-use-trailing-return-type, -readability-convert-member-functions-to-static, -fuchsia-default-arguments-declarations'
+Checks:          '*, -cppcoreguidelines-init-variables, -modernize-return-braced-init-list, -misc-unused-parameters, -misc-non-private-member-variables-in-classes, -llvmlibc-*, -llvm-header-guard, -llvm-include-order, -modernize-use-trailing-return-type, -readability-convert-member-functions-to-static, -fuchsia-default-arguments-declarations, -fuchsia-default-arguments-calls, -*-uppercase-literal-suffix, -fuchsia-overloaded-operator, -google-build-using-namespace, -google-global-names-in-headers'
 HeaderFilterRegex: '.*'
 FormatStyle:     none

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,6 +68,10 @@ jobs:
         with:
           path: ./prebuilds
 
+      - name: Tidy
+        if: ${{ contains(matrix.node_version, '12') && contains(matrix.os, 'ubuntu') }}
+        run: npm run tidy
+
   Skip:
     if: contains(github.event.head_commit.message, '[skip ci]')
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,10 +68,6 @@ jobs:
         with:
           path: ./prebuilds
 
-      - name: Tidy
-        if: ${{ contains(matrix.node_version, '12') && contains(matrix.os, 'ubuntu') }}
-        run: npm run tidy
-
   Skip:
     if: contains(github.event.head_commit.message, '[skip ci]')
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - macos-latest
+          - ubuntu-20.04
+          - macos-11.0
           - windows-latest
         node_version:
           - 10
@@ -26,6 +26,10 @@ jobs:
           - os: windows-2016
             node_version: 12
             node_arch: x86
+          - os: ubuntu-16.04
+            node_version: 12
+          - os: macos-10.15
+            node_version: 12
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,13 +42,24 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-${{ matrix.node_version }}-${{ matrix.node_arch }}-${{ hashFiles('package.json') }}
 
+      - name: Install Compiler
+        if: ${{ contains(matrix.os, 'ubuntu-16.04') }}
+        run: |
+          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 10
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 10
+          sudo update-alternatives --config clang
+          sudo update-alternatives --config clang++
+          echo ::set-env name=CC::clang
+          echo ::set-env name=CXX::clang++
+
       - name: Install Node
         uses: aminya/setup-node@x86
         with:
           node-version: ${{ matrix.node_version }}
           node-arch: ${{ matrix.node_arch }}
 
-      - name: Install dependencies
+      - name: Install dependencies and build
         run: npm install
 
       - name: Run tests

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,13 +8,13 @@
       ],
       'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
       "cflags": [ "-fno-exceptions" ],
-      "cflags_cc": [ "-fno-exceptions", "-std=c++17" ],
+      "cflags_cc": [ "-fno-exceptions", "-std=c++2a" ],
       "conditions": [
         ['OS=="mac"', {
             "xcode_settings": {
               'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
               "CLANG_CXX_LIBRARY": "libc++",
-              "CLANG_CXX_LANGUAGE_STANDARD":"c++17",
+              "CLANG_CXX_LANGUAGE_STANDARD":"c++2a",
               'MACOSX_DEPLOYMENT_TARGET': '10.15'
             }
         }],

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "types": "./types/fuzzaldrin-plus-fast.d.ts",
   "scripts": {
     "format": "clang-format -i src/*.cc src/*.h",
+    "tidy": "clang-tidy src/*.cc src/*.h",
+    "tidy:fix": "clang-tidy src/*.cc src/*.h --fix --fix-errors",
     "native:clean": "shx rm -rf build prebuilds",
     "native:build": "node-gyp-build",
     "native:prebuild": "prebuildify --napi -t 12.0.0 -t electron@6.0.0 --strip",

--- a/src/common.h
+++ b/src/common.h
@@ -48,7 +48,7 @@ struct PreparedQuery {
     Element core_up;
     int depth = 0;
     Element ext;
-    std::set<char> charCodes;
+    std::set<char> charCodes{};
 
     PreparedQuery(const Element &q, char pathSeparator);
 };

--- a/src/common.h
+++ b/src/common.h
@@ -95,7 +95,7 @@ extern Score path_scorer_score(const CandidateString &string, const Element &que
 extern int countDir(const CandidateString &path, int end, char pathSeparator);
 extern CandidateString getExtension(const CandidateString &str);
 
-extern std::vector<CandidateIndex> filter(const vector<std::vector<CandidateString>> &candidates, const Element &query, const Options &options);
+extern const std::vector<CandidateIndex> filter(const vector<std::vector<CandidateString>> &candidates, const Element &query, const Options &options);
 
 extern std::vector<size_t> matcher_match(const CandidateString &string, const Element &query, const Options &options);
 extern void get_wrap(const CandidateString &string, const Element &query, const Options &options, std::string *out);

--- a/src/filter.cc
+++ b/src/filter.cc
@@ -68,8 +68,9 @@ std::vector<CandidateIndex> sort_priority_queue(CandidateScorePriorityQueue &can
 std::vector<CandidateIndex> filter(const vector<std::vector<CandidateString>> &candidates, const Element &query, const Options &options) {
     CandidateScorePriorityQueue top_k;
     size_t max_results = options.max_results;
-    if (!max_results)
+    if (max_results == 0u) {
         max_results = std::numeric_limits<size_t>::max();
+    }
 
     // Split the dataset and pass down to multiple threads.
     vector<thread> threads;

--- a/src/filter.cc
+++ b/src/filter.cc
@@ -67,7 +67,7 @@ const std::vector<CandidateIndex> sort_priority_queue(CandidateScorePriorityQueu
 
 const std::vector<CandidateIndex> filter(const vector<std::vector<CandidateString>> &candidates, const Element &query, const Options &options) {
     CandidateScorePriorityQueue top_k;
-    size_t max_results = options.max_results;
+    auto max_results = options.max_results;
     if (max_results == 0u) {
         max_results = std::numeric_limits<size_t>::max();
     }

--- a/src/filter.cc
+++ b/src/filter.cc
@@ -28,7 +28,7 @@ void filter_internal(const std::vector<CandidateString> &candidates,
     for (size_t i = 0, len = candidates.size(); i < len; i++) {
         const auto &candidate = candidates[i];
         if (candidate.empty()) continue;
-        auto scoreProvider = options.usePathScoring ? path_scorer_score : scorer_score;
+        const auto scoreProvider = options.usePathScoring ? path_scorer_score : scorer_score;
         auto score = scoreProvider(candidate, query, options);
         if (score > 0) {
             results.emplace(score, start_index + i);
@@ -47,7 +47,7 @@ void thread_worker_filter(const std::vector<CandidateString> &candidates,
     filter_internal(candidates, start_index, query, options, max_results, results);
 }
 
-std::vector<CandidateIndex> sort_priority_queue(CandidateScorePriorityQueue &candidates) {
+const std::vector<CandidateIndex> sort_priority_queue(CandidateScorePriorityQueue &candidates) {
     vector<CandidateScore> sorted;
     std::vector<CandidateIndex> ret;
     sorted.reserve(candidates.size());
@@ -65,7 +65,7 @@ std::vector<CandidateIndex> sort_priority_queue(CandidateScorePriorityQueue &can
 
 }// namespace
 
-std::vector<CandidateIndex> filter(const vector<std::vector<CandidateString>> &candidates, const Element &query, const Options &options) {
+const std::vector<CandidateIndex> filter(const vector<std::vector<CandidateString>> &candidates, const Element &query, const Options &options) {
     CandidateScorePriorityQueue top_k;
     size_t max_results = options.max_results;
     if (max_results == 0u) {

--- a/src/fuzzaldrin.cc
+++ b/src/fuzzaldrin.cc
@@ -89,7 +89,7 @@ Napi::Value Fuzzaldrin::FilterTree(const Napi::CallbackInfo &info) {
 
     // create Tree and set candidates
     auto tree = Tree(jsTreeArray, dataKey, childrenKey);
-    Fuzzaldrin::SetCandidates(tree.entriesArray);
+    SetCandidates(tree.entriesArray);
 
     // create options
     Options options(query, maxResults, usePathScoring, useExtensionBonus);

--- a/src/fuzzaldrin.cc
+++ b/src/fuzzaldrin.cc
@@ -8,11 +8,11 @@ Napi::Value Fuzzaldrin::Filter(const Napi::CallbackInfo &info) {
         Napi::TypeError::New(info.Env(), "Invalid arguments").ThrowAsJavaScriptException();
         return Napi::Boolean();
     }
-    std::string query = info[0].As<Napi::String>();
-    size_t maxResults = info[1].As<Napi::Number>().Uint32Value();
-    bool usePathScoring = info[2].As<Napi::Boolean>();
-    bool useExtensionBonus = info[3].As<Napi::Boolean>();
-    Options options(query, maxResults, usePathScoring, useExtensionBonus);
+    const std::string query = info[0].As<Napi::String>();
+    const size_t maxResults = info[1].As<Napi::Number>().Uint32Value();
+    const bool usePathScoring = info[2].As<Napi::Boolean>();
+    const bool useExtensionBonus = info[3].As<Napi::Boolean>();
+    const Options options(query, maxResults, usePathScoring, useExtensionBonus);
     const auto matches = filter(candidates_, query, options);
 
     for (uint32_t i = 0, len = matches.size(); i < len; i++) {
@@ -116,13 +116,13 @@ Napi::Number score(const Napi::CallbackInfo &info) {
     if (info.Length() != 4 || !info[0].IsString() || !info[1].IsString() || !info[2].IsBoolean() || !info[3].IsBoolean()) {
         Napi::TypeError::New(info.Env(), "Invalid arguments").ThrowAsJavaScriptException();
     }
-    std::string candidate = info[0].As<Napi::String>();
-    std::string query = info[1].As<Napi::String>();
-    bool usePathScoring = info[2].As<Napi::Boolean>();
-    bool useExtensionBonus = info[3].As<Napi::Boolean>();
-    Options options(query, 1, usePathScoring, useExtensionBonus);
-    auto scoreProvider = options.usePathScoring ? path_scorer_score : scorer_score;
-    auto score = scoreProvider(candidate, query, options);
+    const std::string candidate = info[0].As<Napi::String>();
+    const std::string query = info[1].As<Napi::String>();
+    const bool usePathScoring = info[2].As<Napi::Boolean>();
+    const bool useExtensionBonus = info[3].As<Napi::Boolean>();
+    const Options options(query, 1, usePathScoring, useExtensionBonus);
+    const auto scoreProvider = options.usePathScoring ? path_scorer_score : scorer_score;
+    const auto score = scoreProvider(candidate, query, options);
     return Napi::Number::New(info.Env(), score);
 }
 

--- a/src/fuzzaldrin.cc
+++ b/src/fuzzaldrin.cc
@@ -3,7 +3,7 @@
 #include "fuzzaldrin.h"
 
 Napi::Value Fuzzaldrin::Filter(const Napi::CallbackInfo &info) {
-    Napi::Array res = Napi::Array::New(info.Env());
+    auto res = Napi::Array::New(info.Env());
     if (info.Length() != 4 || !info[0].IsString() || !info[1].IsNumber() || !info[2].IsBoolean() || !info[3].IsBoolean()) {
         Napi::TypeError::New(info.Env(), "Invalid arguments").ThrowAsJavaScriptException();
         return Napi::Boolean();
@@ -26,19 +26,19 @@ Napi::Value Fuzzaldrin::SetCandidates(const Napi::CallbackInfo &info) {
         Napi::TypeError::New(info.Env(), "Invalid arguments").ThrowAsJavaScriptException();
         return Napi::Boolean();
     }
-    Napi::Array candidates = info[0].As<Napi::Array>();
+    auto candidates = info[0].As<Napi::Array>();
     const size_t N = candidates.Length();
-    const size_t num_chunks = (N < 1000 * kMaxThreads) ? (N / 1000 + 1) : kMaxThreads;
+    const auto num_chunks = N < 1000 * kMaxThreads ? N / 1000 + 1 : kMaxThreads;
     candidates_.clear();
     candidates_.resize(num_chunks);
     size_t cur_start = 0;
     for (size_t i = 0; i < num_chunks; i++) {
-        size_t chunk_size = N / num_chunks;
+        auto chunk_size = N / num_chunks;
         // Distribute remainder among the chunks.
         if (i < N % num_chunks) {
             chunk_size++;
         }
-        for (size_t j = cur_start; j < cur_start + chunk_size; j++) {
+        for (auto j = cur_start; j < cur_start + chunk_size; j++) {
             Napi::Value val = candidates[j];
             candidates_[i].push_back(val.ToString().Utf8Value());
         }
@@ -48,18 +48,18 @@ Napi::Value Fuzzaldrin::SetCandidates(const Napi::CallbackInfo &info) {
 }
 
 void Fuzzaldrin::SetCandidates(vector<CandidateObject> const &candidates) {
-    const size_t N = candidates.size();// different
-    const size_t num_chunks = (N < 1000 * kMaxThreads) ? (N / 1000 + 1) : kMaxThreads;
+    const auto N = candidates.size();// different
+    const auto num_chunks = N < 1000 * kMaxThreads ? N / 1000 + 1 : kMaxThreads;
     candidates_.clear();
     candidates_.resize(num_chunks);
     size_t cur_start = 0;
     for (size_t i = 0; i < num_chunks; i++) {
-        size_t chunk_size = N / num_chunks;
+        auto chunk_size = N / num_chunks;
         // Distribute remainder among the chunks.
         if (i < N % num_chunks) {
             chunk_size++;
         }
-        for (size_t j = cur_start; j < cur_start + chunk_size; j++) {
+        for (auto j = cur_start; j < cur_start + chunk_size; j++) {
             candidates_[i].push_back(candidates[j].data);// different
         }
         cur_start += chunk_size;
@@ -96,7 +96,7 @@ Napi::Value Fuzzaldrin::FilterTree(const Napi::CallbackInfo &info) {
     const auto matches = filter(candidates_, query, options);
 
     // filter
-    Napi::Array filteredCandidateObjects = Napi::Array::New(info.Env());// array of candidate objects (with their address in index and level)
+    auto filteredCandidateObjects = Napi::Array::New(info.Env());// array of candidate objects (with their address in index and level)
     for (uint32_t i = 0, len = matches.size(); i < len; i++) {
         auto entry = tree.entriesArray[matches[i]];//
 
@@ -127,7 +127,7 @@ Napi::Number score(const Napi::CallbackInfo &info) {
 }
 
 Napi::Array match(const Napi::CallbackInfo &info) {
-    Napi::Array res = Napi::Array::New(info.Env());
+    auto res = Napi::Array::New(info.Env());
     if (info.Length() != 3 || !info[0].IsString() || !info[1].IsString() || !info[2].IsString()) {
         Napi::TypeError::New(info.Env(), "Invalid arguments").ThrowAsJavaScriptException();
         return res;
@@ -168,7 +168,7 @@ Napi::String wrap(const Napi::CallbackInfo &info) {
 Napi::Object Fuzzaldrin::Init(Napi::Env env, Napi::Object exports) {
     Napi::HandleScope scope(env);
 
-    Napi::Function func = DefineClass(env, "Fuzzaldrin", { InstanceMethod("filter", &Fuzzaldrin::Filter), InstanceMethod("filterTree", &Fuzzaldrin::FilterTree), InstanceMethod("setCandidates", &Fuzzaldrin::SetCandidates) });
+    const auto func = DefineClass(env, "Fuzzaldrin", { InstanceMethod("filter", &Fuzzaldrin::Filter), InstanceMethod("filterTree", &Fuzzaldrin::FilterTree), InstanceMethod("setCandidates", &Fuzzaldrin::SetCandidates) });
 
     exports.Set("Fuzzaldrin", func);
     exports.Set("score", Napi::Function::New(env, score));

--- a/src/fuzzaldrin.h
+++ b/src/fuzzaldrin.h
@@ -12,7 +12,7 @@
 class Fuzzaldrin : public Napi::ObjectWrap<Fuzzaldrin> {
   public:
     static Napi::Object Init(Napi::Env env, Napi::Object exports);
-    Fuzzaldrin(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Fuzzaldrin>(info) {}
+    explicit Fuzzaldrin(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Fuzzaldrin>(info) {}
 
     Napi::Value Filter(const Napi::CallbackInfo &info);
     Napi::Value SetCandidates(const Napi::CallbackInfo &info);
@@ -21,7 +21,7 @@ class Fuzzaldrin : public Napi::ObjectWrap<Fuzzaldrin> {
     Napi::Value FilterTree(const Napi::CallbackInfo &info);
 
   private:
-    vector<std::vector<CandidateString>> candidates_;
+    vector<std::vector<CandidateString>> candidates_{};
 };
 
 #endif// FUZZALDRIN_H

--- a/src/matcher.cc
+++ b/src/matcher.cc
@@ -89,7 +89,7 @@ std::vector<size_t> computeMatch(const CandidateString &subject, const Candidate
 
             score_row[j] = score;
             csc_row[j] = csc_score;
-            trace[++pos] = (score > 0) ? move : STOP;
+            trace[++pos] = score > 0 ? move : STOP;
         }
     }
 

--- a/src/matcher.cc
+++ b/src/matcher.cc
@@ -38,27 +38,26 @@ std::vector<size_t> computeMatch(const CandidateString &subject, const Candidate
 
     // Traceback matrix
     std::vector<Direction> trace(m * n, STOP);
-    int pos = -1;
+    auto pos = -1;
 
-    int i = -1;
+    auto i = -1;
     while (++i < m) {//foreach char si of subject
         Score score = 0;
         Score score_up = 0;
         Score csc_diag = 0;
-        char si_lw = subject_lw[i];
+        const auto si_lw = subject_lw[i];
 
-        int j = -1;//0..n-1
+        auto j = -1;//0..n-1
         while (++j < n) {//foreach char qj of query
             // reset score
             Score csc_score = 0;
             Score align = 0;
-            Score score_diag = score_up;
+            const auto score_diag = score_up;
             Direction move;
 
             //Compute a tentative match
             if (query_lw[j] == si_lw) {
-
-                auto start = isWordStart(i, subject, subject_lw);
+                const auto start = isWordStart(i, subject, subject_lw);
 
                 // Forward search for a sequence of consecutive char
                 csc_score = csc_diag > 0 ? csc_diag : scoreConsecutives(subject, subject_lw, query, query_lw, i, j, start);
@@ -99,9 +98,9 @@ std::vector<size_t> computeMatch(const CandidateString &subject, const Candidate
     // and collect matches (diagonals)
 
     i = m - 1;
-    int j = n - 1;
+    auto j = n - 1;
     pos = i * n + j;
-    bool backtrack = true;
+    auto backtrack = true;
     std::vector<size_t> matches;
 
     while (backtrack && i >= 0 && j >= 0) {
@@ -137,14 +136,14 @@ std::vector<size_t> basenameMatch(const CandidateString &subject, const Candidat
     }
 
     // Get position of basePath of subject.
-    size_t basePos = subject.rfind(pathSeparator, end);
+    auto basePos = subject.rfind(pathSeparator, end);
 
     // If no PathSeparator, no base path exist.
     if (basePos == std::string::npos)
         return std::vector<size_t>();
 
     // Get the number of folder in query
-    int depth = preparedQuery.depth;
+    auto depth = preparedQuery.depth;
 
     // Get that many folder from subject
     while (depth-- > 0) {
@@ -174,13 +173,13 @@ std::vector<size_t> mergeMatches(const std::vector<size_t> &a, const std::vector
     if (n == 0) return a;
     if (m == 0) return b;
 
-    int i = -1;
-    int j = 0;
-    size_t bj = b[j];
+    auto i = -1;
+    auto j = 0;
+    auto bj = b[j];
     std::vector<size_t> out;
 
     while (++i < m) {
-        size_t ai = a[i];
+        auto ai = a[i];
 
         while (bj <= ai && ++j < n) {
             if (bj < ai)
@@ -229,9 +228,8 @@ void get_wrap(const CandidateString &string, const Element &query, const Options
     std::string output;
     size_t matchIndex = 0;
     size_t strPos = 0;
-    size_t matchPos;
     while (matchIndex < matchPositions.size()) {
-        matchPos = matchPositions[matchIndex];
+        auto matchPos = matchPositions[matchIndex];
         matchIndex++;
 
         // Get text before the current match position

--- a/src/matcher.cc
+++ b/src/matcher.cc
@@ -132,8 +132,9 @@ std::vector<size_t> computeMatch(const CandidateString &subject, const Candidate
 std::vector<size_t> basenameMatch(const CandidateString &subject, const CandidateString &subject_lw, const PreparedQuery &preparedQuery, char pathSeparator) {
     // Skip trailing slashes
     int end = subject.size() - 1;
-    while (subject[end] == pathSeparator)
+    while (subject[end] == pathSeparator) {
         end--;
+    }
 
     // Get position of basePath of subject.
     size_t basePos = subject.rfind(pathSeparator, end);
@@ -261,8 +262,9 @@ void get_wrap(const CandidateString &string, const Element &query, const Options
     }
 
     // Get string after last match
-    if (strPos <= string.size() - 1)
+    if (strPos <= string.size() - 1) {
         output += string.substr(strPos);
+    }
 
     // return wrapped text
     *out = output;

--- a/src/matcher.cc
+++ b/src/matcher.cc
@@ -19,12 +19,12 @@ std::vector<size_t> computeMatch(const CandidateString &subject, const Candidate
     const auto &query = preparedQuery.query;
     const auto &query_lw = preparedQuery.query_lw;
 
-    int m = subject.size();
-    int n = query.size();
+    const int m = subject.size();
+    const int n = query.size();
 
     // this is like the consecutive bonus, but for camelCase / snake_case initials
-    auto acro = scoreAcronyms(subject, subject_lw, query, query_lw);
-    auto acro_score = acro.score;
+    const auto acro = scoreAcronyms(subject, subject_lw, query, query_lw);
+    const auto acro_score = acro.score;
 
     // Init
     vector<Score> score_row(n, 0);
@@ -168,8 +168,8 @@ std::vector<size_t> basenameMatch(const CandidateString &subject, const Candidat
 // (Assume sequences are sorted, matches are sorted by construction.)
 //
 std::vector<size_t> mergeMatches(const std::vector<size_t> &a, const std::vector<size_t> &b) {
-    int m = a.size();
-    int n = b.size();
+    const int m = a.size();
+    const int n = b.size();
 
     if (n == 0) return a;
     if (m == 0) return b;
@@ -200,16 +200,16 @@ std::vector<size_t> matcher_match(const CandidateString &string, const Element &
     auto matches = computeMatch(string, string_lw, options.preparedQuery);
 
     if (string.find(options.pathSeparator) != std::string::npos) {
-        auto baseMatches = basenameMatch(string, string_lw, options.preparedQuery, options.pathSeparator);
+        const auto baseMatches = basenameMatch(string, string_lw, options.preparedQuery, options.pathSeparator);
         return mergeMatches(matches, baseMatches);
     }
     return matches;
 }
 
 void get_wrap(const CandidateString &string, const Element &query, const Options &options, std::string *out) {
-    std::string tagClass = "highlight";
-    std::string tagOpen = "<strong class=\"" + tagClass + "\">";
-    std::string tagClose = "</strong>";
+    const std::string tagClass = "highlight";
+    const auto tagOpen = "<strong class=\"" + tagClass + "\">";
+    const std::string tagClose = "</strong>";
 
     if (string == query) {
         *out = tagOpen + string + tagClose;

--- a/src/path_scorer.cc
+++ b/src/path_scorer.cc
@@ -96,8 +96,8 @@ Score scorePath(const CandidateString &subject, const CandidateString &subject_l
     // A penalty based on the size of the basePath is applied to fullPathScore
     // That way, more focused basePath match can overcome longer directory path.
 
-    Score alpha = 0.5 * tau_depth / (tau_depth + countDir(subject, end + 1, options.pathSeparator));
     return alpha * basePathScore + (1 - alpha) * fullPathScore * scoreSize(0, file_coeff * (fileLength));
+    const Score alpha = 0.5 * tau_depth / (tau_depth + countDir(subject, end + 1, options.pathSeparator));
 }
 
 
@@ -136,8 +136,8 @@ int countDir(const CandidateString &path, int end, char pathSeparator) {
 // This need special handling because it give point for not having characters (the `tml` in above example)
 //
 CandidateString getExtension(const CandidateString &str) {
-    auto pos = str.rfind('.');
     return (pos == string::npos) ? "" : str.substr(pos + 1);
+    const auto pos = str.rfind('.');
 }
 
 

--- a/src/path_scorer.cc
+++ b/src/path_scorer.cc
@@ -178,5 +178,5 @@ Score getExtensionScore(const CandidateString &candidate, const CandidateString 
     }
 
     // cannot divide by zero because m is the largest extension length and we return if either is 0
-    return Score(matched) / m;
+    return static_cast<Score>(matched) / m;
 }

--- a/src/path_scorer.cc
+++ b/src/path_scorer.cc
@@ -96,8 +96,8 @@ Score scorePath(const CandidateString &subject, const CandidateString &subject_l
     // A penalty based on the size of the basePath is applied to fullPathScore
     // That way, more focused basePath match can overcome longer directory path.
 
-    return alpha * basePathScore + (1 - alpha) * fullPathScore * scoreSize(0, file_coeff * (fileLength));
     const Score alpha = 0.5 * tau_depth / (tau_depth + countDir(subject, end + 1, options.pathSeparator));
+    return alpha * basePathScore + (1 - alpha) * fullPathScore * scoreSize(0, file_coeff * fileLength);
 }
 
 
@@ -136,8 +136,8 @@ int countDir(const CandidateString &path, int end, char pathSeparator) {
 // This need special handling because it give point for not having characters (the `tml` in above example)
 //
 CandidateString getExtension(const CandidateString &str) {
-    return (pos == string::npos) ? "" : str.substr(pos + 1);
     const auto pos = str.rfind('.');
+    return pos == string::npos ? "" : str.substr(pos + 1);
 }
 
 

--- a/src/path_scorer.cc
+++ b/src/path_scorer.cc
@@ -16,13 +16,13 @@ extern Score scorePath(const CandidateString &subject, const CandidateString &su
 extern Score getExtensionScore(const CandidateString &candidate, const CandidateString &ext, int startPos, int endPos, int maxDepth);
 
 Element ToLower(const Element &s) {
-    Element snew = s;
+    auto snew = s;
     std::transform(s.begin(), s.end(), snew.begin(), ::tolower);
     return snew;
 }
 
 Element ToUpper(const Element &s) {
-    Element snew = s;
+    auto snew = s;
     std::transform(s.begin(), s.end(), snew.begin(), ::toupper);
     return snew;
 }
@@ -63,7 +63,7 @@ Score scorePath(const CandidateString &subject, const CandidateString &subject_l
 
     // Get position of basePath of subject.
     int basePos = subject.rfind(options.pathSeparator, end);
-    int fileLength = end - basePos;
+    const auto fileLength = end - basePos;
 
     // Get a bonus for matching extension
     Score extAdjust = 1.0;
@@ -79,7 +79,7 @@ Score scorePath(const CandidateString &subject, const CandidateString &subject_l
     }
 
     // Get the number of folder in query
-    int depth = options.preparedQuery.depth;
+    auto depth = options.preparedQuery.depth;
 
     // Get that many folder from subject
     while (basePos > -1 && depth-- > 0) {
@@ -88,7 +88,7 @@ Score scorePath(const CandidateString &subject, const CandidateString &subject_l
 
     // Get basePath score, if BaseName is the whole string, no need to recompute
     // We still need to apply the folder depth and filename penalty.
-    Score basePathScore = (basePos == -1) ? fullPathScore : extAdjust * computeScore(subject.substr(basePos + 1, end + 1), subject_lw.substr(basePos + 1, end + 1), options.preparedQuery);
+    const auto basePathScore = basePos == -1 ? fullPathScore : extAdjust * computeScore(subject.substr(basePos + 1, end + 1), subject_lw.substr(basePos + 1, end + 1), options.preparedQuery);
 
     // Final score is linear interpolation between base score and full path score.
     // For low directory depth, interpolation favor base Path then include more of full path as depth increase
@@ -110,8 +110,8 @@ int countDir(const CandidateString &path, int end, char pathSeparator) {
         return 0;
     }
 
-    int count = 0;
-    int i = -1;
+    auto count = 0;
+    auto i = -1;
 
     //skip slash at the start so `foo/bar` and `/foo/bar` have the same depth.
     while (++i < end && path[i] == pathSeparator) {
@@ -155,7 +155,7 @@ Score getExtensionScore(const CandidateString &candidate, const CandidateString 
     }
 
     int n = ext.size();
-    int m = endPos - pos;
+    auto m = endPos - pos;
 
     // n contain the smallest of both extension length, m the largest.
     if (m < n) {
@@ -165,7 +165,7 @@ Score getExtensionScore(const CandidateString &candidate, const CandidateString 
 
     //place cursor after dot & count number of matching characters in extension
     pos++;
-    int matched = -1;
+    auto matched = -1;
     while (++matched < n) {
         if (candidate[pos + matched] != ext[matched]) {
             break;

--- a/src/path_scorer.cc
+++ b/src/path_scorer.cc
@@ -12,7 +12,7 @@ Score file_coeff = 2.5;
 
 
 extern Score scorePath(const CandidateString &subject, const CandidateString &subject_lw, Score fullPathScore, const Options &options);
-extern int countDir(const CandidateString &path, int end, char pathSeparator);
+
 extern Score getExtensionScore(const CandidateString &candidate, const CandidateString &ext, int startPos, int endPos, int maxDepth);
 
 Element ToLower(const Element &s) {
@@ -49,14 +49,17 @@ Score path_scorer_score(const CandidateString &string, const Element &query, con
 // Score adjustment for path
 //
 Score scorePath(const CandidateString &subject, const CandidateString &subject_lw, Score fullPathScore, const Options &options) {
-    if (fullPathScore == 0) return 0;
+    if (fullPathScore == 0) {
+        return 0;
+    }
 
     // {preparedQuery, useExtensionBonus, pathSeparator} = options
 
     // Skip trailing slashes
     int end = subject.size() - 1;
-    while (subject[end] == options.pathSeparator)
+    while (subject[end] == options.pathSeparator) {
         end--;
+    }
 
     // Get position of basePath of subject.
     int basePos = subject.rfind(options.pathSeparator, end);
@@ -71,7 +74,9 @@ Score scorePath(const CandidateString &subject, const CandidateString &subject_l
     }
 
     // no basePath, nothing else to compute.
-    if (basePos == -1) return fullPathScore;
+    if (basePos == -1) {
+        return fullPathScore;
+    }
 
     // Get the number of folder in query
     int depth = options.preparedQuery.depth;
@@ -101,20 +106,24 @@ Score scorePath(const CandidateString &subject, const CandidateString &subject_l
 // (consecutive slashes count as a single directory)
 //
 int countDir(const CandidateString &path, int end, char pathSeparator) {
-    if (end < 1) return 0;
+    if (end < 1) {
+        return 0;
+    }
 
     int count = 0;
     int i = -1;
 
     //skip slash at the start so `foo/bar` and `/foo/bar` have the same depth.
-    while (++i < end && path[i] == pathSeparator)
+    while (++i < end && path[i] == pathSeparator) {
         continue;
+    }
 
     while (++i < end) {
         if (path[i] == pathSeparator) {
             count++;//record first slash, but then skip consecutive ones
-            while (++i < end && path[i] == pathSeparator)
+            while (++i < end && path[i] == pathSeparator) {
                 continue;
+            }
         }
     }
 
@@ -135,11 +144,15 @@ CandidateString getExtension(const CandidateString &str) {
 Score getExtensionScore(const CandidateString &candidate, const CandidateString &ext, int startPos, int endPos, int maxDepth) {
     // startPos is the position of last slash of candidate, -1 if absent.
 
-    if (!ext.size()) return 0;
+    if (ext.empty()) {
+        return 0;
+    }
 
     // Check that (a) extension exist, (b) it is after the start of the basename
     int pos = candidate.rfind('.', endPos);
-    if (pos <= startPos) return 0;// (note that startPos >= -1)
+    if (pos <= startPos) {
+        return 0;// (note that startPos >= -1)
+    }
 
     int n = ext.size();
     int m = endPos - pos;
@@ -154,8 +167,9 @@ Score getExtensionScore(const CandidateString &candidate, const CandidateString 
     pos++;
     int matched = -1;
     while (++matched < n) {
-        if (candidate[pos + matched] != ext[matched])
+        if (candidate[pos + matched] != ext[matched]) {
             break;
+        }
     }
 
     // if nothing found, try deeper for multiple extensions, with some penalty for depth

--- a/src/path_scorer.cc
+++ b/src/path_scorer.cc
@@ -114,16 +114,12 @@ int countDir(const CandidateString &path, int end, char pathSeparator) {
     auto i = -1;
 
     //skip slash at the start so `foo/bar` and `/foo/bar` have the same depth.
-    while (++i < end && path[i] == pathSeparator) {
-        continue;
-    }
+    while (++i < end && path[i] == pathSeparator) { }
 
     while (++i < end) {
         if (path[i] == pathSeparator) {
             count++;//record first slash, but then skip consecutive ones
-            while (++i < end && path[i] == pathSeparator) {
-                continue;
-            }
+            while (++i < end && path[i] == pathSeparator) { }
         }
     }
 

--- a/src/query.cc
+++ b/src/query.cc
@@ -23,8 +23,8 @@ Element coreChars(Element query) {
 
 std::set<char> getCharCodes(const Element &str) {
     std::set<char> charCodes;
-    int len = str.size();
     int i = -1;
+    const int len = str.size();
 
     // create map
     while (++i < len)

--- a/src/query.cc
+++ b/src/query.cc
@@ -15,7 +15,7 @@ PreparedQuery::PreparedQuery(const Element &q, char pathSeparator) : query(q), q
 
 
 Element coreChars(Element query) {
-    for (char ch : " _-:/\\") {
+    for (auto ch : " _-:/\\") {
         query.erase(std::remove(query.begin(), query.end(), ch), query.end());
     }
     return query;
@@ -23,8 +23,8 @@ Element coreChars(Element query) {
 
 std::set<char> getCharCodes(const Element &str) {
     std::set<char> charCodes;
-    int i = -1;
     const int len = str.size();
+    auto i = -1;
 
     // create map
     while (++i < len)

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -68,18 +68,18 @@ bool isMatch(const CandidateString &subject, const Element &query_lw, const Elem
         return false;
     }
 
-    int i = -1;
-    int j = -1;
+    auto i = -1;
+    auto j = -1;
 
     // foreach char of query
     while (++j < n) {
-        char qj_lw = query_lw[j];
-        char qj_up = query_up[j];
+        const auto qj_lw = query_lw[j];
+        const auto qj_up = query_up[j];
 
         // continue walking the subject from where we have left with previous query char
         // until we have found a character that is either lowercase or uppercase query.
         while (++i < m) {
-            char si = subject[i];
+            const auto si = subject[i];
             if (si == qj_lw || si == qj_up) {
                 break;
             }
@@ -141,7 +141,7 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
 
     const auto miss_budget = ceil(miss_coeff * n) + 5;
     auto miss_left = miss_budget;
-    bool csc_should_rebuild = true;
+    auto csc_should_rebuild = true;
 
     // Fill with 0
     /*
@@ -151,16 +151,16 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
     csc_row[j] = 0;
   }*/
 
-    int i = -1;
+    auto i = -1;
     while (++i < m) {//foreach char si of subject
-        char si_lw = subject_lw[i];
+        auto si_lw = subject_lw[i];
 
         // if si_lw is not in query
         if (preparedQuery.charCodes.find(si_lw) == preparedQuery.charCodes.end()) {
             // reset csc_row and move to next subject char
             // unless we just cleaned it then keep cleaned version.
             if (csc_should_rebuild) {
-                int j = -1;
+                auto j = -1;
                 while (++j < n) {
                     csc_row[j] = 0;
                 }
@@ -172,16 +172,16 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
         Score score = 0;
         Score score_diag = 0;
         Score csc_diag = 0;
-        bool record_miss = true;
+        auto record_miss = true;
         csc_should_rebuild = true;
 
-        int j = -1;//0..n-1
+        auto j = -1;//0..n-1
         while (++j < n) {//foreach char qj of query
 
             // What is the best gap ?
             // score_up contain the score of a gap in subject.
             // score_left = last iteration of score, -> gap in query.
-            Score score_up = score_row[j];
+            const auto score_up = score_row[j];
             if (score_up > score) {
                 score = score_up;
             }
@@ -241,8 +241,8 @@ bool isWordStart(int pos, const CandidateString &subject, const CandidateString 
     if (pos == 0) {
         return true;// match is FIRST char ( place a virtual token separator before first char of string)
     }
-    char curr_s = subject[pos];
-    char prev_s = subject[pos - 1];
+    const auto curr_s = subject[pos];
+    const auto prev_s = subject[pos - 1];
     return isSeparator(prev_s) ||// match FOLLOW a separator
            (curr_s != subject_lw[pos] && prev_s == subject_lw[pos - 1]);// match is Capital in camelCase (preceded by lowercase)
 }
@@ -251,8 +251,8 @@ bool isWordEnd(int pos, const CandidateString &subject, const CandidateString &s
     if (pos == len - 1) {
         return true;// last char of string
     }
-    char curr_s = subject[pos];
-    char next_s = subject[pos + 1];
+    const auto curr_s = subject[pos];
+    const auto next_s = subject[pos + 1];
     return isSeparator(next_s) ||// match IS FOLLOWED BY a separator
            (curr_s == subject_lw[pos] && next_s != subject_lw[pos + 1]);// match is lowercase, followed by uppercase
 }
@@ -266,7 +266,7 @@ bool isSeparator(char c) {
 //
 Score scorePosition(Score pos) {
     if (pos < pos_bonus) {
-        Score sc = pos_bonus - pos;
+        const auto sc = pos_bonus - pos;
         return 100 + sc * sc;
     }
     return fmax(100 + pos_bonus - pos, 0);
@@ -291,7 +291,7 @@ Score scoreExact(size_t n, size_t m, size_t quality, Score pos) {
 Score scorePattern(int count, int len, int sameCase, bool start, bool end) {
     auto sz = count;
 
-    int bonus = 6;// to ensure consecutive length dominate score, this should be as large other bonus combined
+    auto bonus = 6;// to ensure consecutive length dominate score, this should be as large other bonus combined
     if (sameCase == count) {
         bonus += 2;
     }
@@ -326,7 +326,7 @@ Score scorePattern(int count, int len, int sameCase, bool start, bool end) {
 Score scoreCharacter(int i, int j, bool start, Score acro_score, Score csc_score) {
 
     // start of string / position of match bonus
-    Score posBonus = scorePosition(i);
+    const auto posBonus = scorePosition(i);
 
     // match IS a word boundary
     // choose between taking part of consecutive characters or consecutive acronym
@@ -348,11 +348,10 @@ Score scoreConsecutives(const CandidateString &subject, const CandidateString &s
 
     int mi = m - i;
     int nj = n - j;
-    int k = mi < nj ? mi : nj;
     const auto k = mi < nj ? mi : nj;
 
-    int sameCase = 0;
-    int sz = 0;//sz will be one more than the last qi is sj
+    auto sameCase = 0;
+    auto sz = 0;//sz will be one more than the last qi is sj
 
     // query_lw[i] is subject_lw[j] has been checked before entering now do case sensitive check.
     if (query[j] == subject[i]) {
@@ -391,7 +390,7 @@ Score scoreConsecutives(const CandidateString &subject, const CandidateString &s
 Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, int n, int m) {
 
     // Test for word start
-    bool start = isWordStart(pos, subject, subject_lw);
+    auto start = isWordStart(pos, subject, subject_lw);
 
     // Heuristic
     // If not a word start, test next occurrence
@@ -410,15 +409,15 @@ Score scoreExactMatch(const CandidateString &subject, const CandidateString &sub
     }
 
     //Exact case bonus.
-    int i = -1;
-    int sameCase = 0;
+    auto i = -1;
+    auto sameCase = 0;
     while (++i < n) {
         if (query[i] == subject[pos + i]) {
             sameCase++;
         }
     }
 
-    int end = static_cast<int>(isWordEnd(pos + n - 1, subject, subject_lw, m));
+    const auto end = static_cast<int>(isWordEnd(pos + n - 1, subject, subject_lw, m));
 
     Score baseNameStart = 1.0;
     if (start && pos > 0 && (subject[pos - 1] == '/' || subject[pos - 1] == '\\')) {
@@ -445,16 +444,15 @@ AcronymResult scoreAcronyms(CandidateString subject, CandidateString subject_lw,
     }
 
     size_t count = 0;
-    int sepCount = 0;
-    int sumPos = 0;
-    int sameCase = 0;
+    auto sepCount = 0;
+    auto sumPos = 0;
+    auto sameCase = 0;
 
-    size_t i = string::npos;// incrementing will become 0
+    auto i = string::npos;// incrementing will become 0
 
     //foreach char of query
     for (size_t j = 0; j < n; j++) {
-
-        char qj_lw = query_lw[j];
+        const auto qj_lw = query_lw[j];
 
         // Separator will not score point but will continue the prefix when present.
         // Test that the separator is in the candidate and advance cursor to that position.
@@ -498,7 +496,7 @@ AcronymResult scoreAcronyms(CandidateString subject, CandidateString subject_lw,
 
     // Acronym are scored as start-of-word
     // Unless the acronym is a 1:1 match with candidate then it is upgraded to full-word.
-    bool fullWord = count == n ? isAcronymFullWord(subject, subject_lw, query, count) : false;
+    const auto fullWord = count == n ? isAcronymFullWord(subject, subject_lw, query, count) : false;
     const auto score = scorePattern(count, n, sameCase, true, fullWord);
 
     return AcronymResult(score, Score(sumPos) / count, count + sepCount);
@@ -525,7 +523,7 @@ bool isAcronymFullWord(const CandidateString &subject, const CandidateString &su
         return false;
     }
 
-    int i = -1;
+    auto i = -1;
     while (++i < m) {
         //For each char of subject
         //Test if we have an acronym, if so increase acronym count.

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -37,7 +37,7 @@ extern Score scoreExact(size_t n, size_t m, size_t quality, Score pos);
 extern Score scorePattern(int count, int len, bool sameCase, bool start, bool end);
 extern Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, int n, int m);
 
-extern bool isAcronymFullWord(CandidateString subject, CandidateString subject_lw, Element query, int nbAcronymInQuery);
+extern bool isAcronymFullWord(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, int nbAcronymInQuery);
 
 
 //
@@ -64,8 +64,9 @@ bool isMatch(const CandidateString &subject, const Element &query_lw, const Elem
     int m = subject.size();
     int n = query_lw.size();
 
-    if (!m || n > m)
+    if ((m == 0) || n > m) {
         return false;
+    }
 
     int i = -1;
     int j = -1;
@@ -79,12 +80,15 @@ bool isMatch(const CandidateString &subject, const Element &query_lw, const Elem
         // until we have found a character that is either lowercase or uppercase query.
         while (++i < m) {
             char si = subject[i];
-            if (si == qj_lw || si == qj_up)
+            if (si == qj_lw || si == qj_up) {
                 break;
+            }
         }
 
         // if we passed the last char, query is not in subject
-        if (i == m) return false;
+        if (i == m) {
+            return false;
+        }
     }
 
     // Found every char of query in subject in proper order, match is positive
@@ -111,8 +115,9 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
 
     // Whole query is abbreviation ?
     // => use that as score
-    if (acro.count == n)
+    if (acro.count == n) {
         return scoreExact(n, m, acro_score, acro.pos);
+    }
 
     //----------------------------
     // Exact Match ?
@@ -177,7 +182,9 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
             // score_up contain the score of a gap in subject.
             // score_left = last iteration of score, -> gap in query.
             Score score_up = score_row[j];
-            if (score_up > score) score = score_up;
+            if (score_up > score) {
+                score = score_up;
+            }
 
             //Reset consecutive
             Score csc_score = 0;
@@ -232,7 +239,9 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
 // Fortunately those small function inline well.
 //
 bool isWordStart(int pos, const CandidateString &subject, const CandidateString &subject_lw) {
-    if (pos == 0) return true;// match is FIRST char ( place a virtual token separator before first char of string)
+    if (pos == 0) {
+        return true;// match is FIRST char ( place a virtual token separator before first char of string)
+    }
     char curr_s = subject[pos];
     char prev_s = subject[pos - 1];
     return isSeparator(prev_s) ||// match FOLLOW a separator
@@ -240,7 +249,9 @@ bool isWordStart(int pos, const CandidateString &subject, const CandidateString 
 }
 
 bool isWordEnd(int pos, const CandidateString &subject, const CandidateString &subject_lw, int len) {
-    if (pos == len - 1) return true;// last char of string
+    if (pos == len - 1) {
+        return true;// last char of string
+    }
     char curr_s = subject[pos];
     char next_s = subject[pos + 1];
     return isSeparator(next_s) ||// match IS FOLLOWED BY a separator
@@ -258,9 +269,8 @@ Score scorePosition(Score pos) {
     if (pos < pos_bonus) {
         Score sc = pos_bonus - pos;
         return 100 + sc * sc;
-    } else {
-        return fmax(100 + pos_bonus - pos, 0);
     }
+    return fmax(100 + pos_bonus - pos, 0);
 }
 
 Score scoreSize(Score n, Score m) {
@@ -283,9 +293,15 @@ Score scorePattern(int count, int len, int sameCase, bool start, bool end) {
     auto sz = count;
 
     int bonus = 6;// to ensure consecutive length dominate score, this should be as large other bonus combined
-    if (sameCase == count) bonus += 2;
-    if (start) bonus += 3;
-    if (end) bonus += 1;
+    if (sameCase == count) {
+        bonus += 2;
+    }
+    if (start) {
+        bonus += 3;
+    }
+    if (end) {
+        bonus += 1;
+    }
 
     if (count == len) {
         // when we match 100% of query we allow to break the size ordering.
@@ -297,8 +313,9 @@ Score scorePattern(int count, int len, int sameCase, bool start, bool end) {
                 sz += 1;
             }
         }
-        if (end)
+        if (end) {
             bonus += 1;
+        }
     }
 
     return sameCase + sz * (sz + bonus);
@@ -338,22 +355,31 @@ Score scoreConsecutives(const CandidateString &subject, const CandidateString &s
     int sz = 0;//sz will be one more than the last qi is sj
 
     // query_lw[i] is subject_lw[j] has been checked before entering now do case sensitive check.
-    if (query[j] == subject[i]) sameCase++;
+    if (query[j] == subject[i]) {
+        sameCase++;
+    }
 
     //Continue while lowercase char are the same, record when they are case-sensitive match.
-    while (++sz < k && query_lw[++j] == subject_lw[++i])
-        if (query[j] == subject[i]) sameCase++;
+    while (++sz < k && query_lw[++j] == subject_lw[++i]) {
+        if (query[j] == subject[i]) {
+            sameCase++;
+        }
+    }
 
 
     // If we quit because of a non match
     // replace cursor to the last match
-    if (sz < k) i--;
+    if (sz < k) {
+        i--;
+    }
 
     // Faster path for single match.
     // Isolated character match occurs often and are not really interesting.
     // Fast path so we don't compute expensive pattern score on them.
     // Acronym should be addressed with acronym context bonus instead of consecutive.
-    if (sz == 1) return 1 + 2 * sameCase;
+    if (sz == 1) {
+        return 1 + 2 * sameCase;
+    }
 
     return scorePattern(sz, n, sameCase, startOfWord, isWordEnd(i, subject, subject_lw, m));
 }
@@ -377,7 +403,9 @@ Score scoreExactMatch(const CandidateString &subject, const CandidateString &sub
         auto pos2 = subject_lw.find(query_lw, pos + 1);
         if (pos2 != string::npos) {
             start = isWordStart(pos2, subject, subject_lw);
-            if (start) pos = pos2;
+            if (start) {
+                pos = pos2;
+            }
         }
     }
 
@@ -385,18 +413,19 @@ Score scoreExactMatch(const CandidateString &subject, const CandidateString &sub
     int i = -1;
     int sameCase = 0;
     while (++i < n) {
-        if (query[i] == subject[pos + i])
+        if (query[i] == subject[pos + i]) {
             sameCase++;
+        }
     }
 
-    int end = isWordEnd(pos + n - 1, subject, subject_lw, m);
+    int end = static_cast<int>(isWordEnd(pos + n - 1, subject, subject_lw, m));
 
     Score baseNameStart = 1.0;
     if (start && pos > 0 && (subject[pos - 1] == '/' || subject[pos - 1] == '\\')) {
         baseNameStart = static_cast<Score>(1.1);
     }
 
-    return scoreExact(n, m, baseNameStart * scorePattern(n, n, sameCase, start, end), pos);
+    return scoreExact(n, m, baseNameStart * scorePattern(n, n, sameCase, start, end != 0), pos);
 }
 
 
@@ -411,7 +440,9 @@ AcronymResult scoreAcronyms(CandidateString subject, CandidateString subject_lw,
     auto n = query.size();
 
     //a single char is not an acronym
-    if (m <= 1 || n <= 1) return emptyAcronymResult;
+    if (m <= 1 || n <= 1) {
+        return emptyAcronymResult;
+    }
 
     size_t count = 0;
     int sepCount = 0;
@@ -434,9 +465,8 @@ AcronymResult scoreAcronyms(CandidateString subject, CandidateString subject_lw,
             if (i != string::npos) {
                 sepCount++;
                 continue;
-            } else {
-                break;
             }
+            break;
         }
 
         // For other characters we search for the first match where subject[i] = query[j]
@@ -444,8 +474,9 @@ AcronymResult scoreAcronyms(CandidateString subject, CandidateString subject_lw,
 
         while (++i < m) {
             if (qj_lw == subject_lw[i] && isWordStart(i, subject, subject_lw)) {
-                if (query[j] == subject[i])
+                if (query[j] == subject[i]) {
                     sameCase++;
+                }
                 sumPos += i;
                 count++;
                 break;
@@ -453,14 +484,17 @@ AcronymResult scoreAcronyms(CandidateString subject, CandidateString subject_lw,
         }
 
         // All of subject is consumed, stop processing the query.
-        if (i == m) break;
+        if (i == m) {
+            break;
+        }
     }
 
 
     // Here, all of query is consumed (or we have reached a character not in acronym)
     // A single character is not an acronym (also prevent division by 0)
-    if (count < 2)
+    if (count < 2) {
         return emptyAcronymResult;
+    }
 
     // Acronym are scored as start-of-word
     // Unless the acronym is a 1:1 match with candidate then it is upgraded to full-word.
@@ -479,7 +513,7 @@ AcronymResult scoreAcronyms(CandidateString subject, CandidateString subject_lw,
 //
 // This method check for (b) assuming (a) has been checked before entering.
 
-bool isAcronymFullWord(CandidateString subject, CandidateString subject_lw, Element query, int nbAcronymInQuery) {
+bool isAcronymFullWord(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, int nbAcronymInQuery) {
     int m = subject.size();
     int n = query.size();
     int count = 0;
@@ -487,7 +521,9 @@ bool isAcronymFullWord(CandidateString subject, CandidateString subject_lw, Elem
     // Heuristic:
     // Assume one acronym every (at most) 12 character on average
     // This filter out long paths, but then they can match on the filename.
-    if (m > 12 * n) return false;
+    if (m > 12 * n) {
+        return false;
+    }
 
     int i = -1;
     while (++i < m) {

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -499,7 +499,7 @@ AcronymResult scoreAcronyms(CandidateString subject, CandidateString subject_lw,
     const auto fullWord = count == n ? isAcronymFullWord(subject, subject_lw, query, count) : false;
     const auto score = scorePattern(count, n, sameCase, true, fullWord);
 
-    return AcronymResult(score, Score(sumPos) / count, count + sepCount);
+    return AcronymResult(score, static_cast<Score>(sumPos) / count, count + sepCount);
 }
 
 

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -64,7 +64,7 @@ bool isMatch(const CandidateString &subject, const Element &query_lw, const Elem
     const int m = subject.size();
     const int n = query_lw.size();
 
-    if ((m == 0) || n > m) {
+    if (m == 0 || n > m) {
         return false;
     }
 
@@ -244,7 +244,7 @@ bool isWordStart(int pos, const CandidateString &subject, const CandidateString 
     const auto curr_s = subject[pos];
     const auto prev_s = subject[pos - 1];
     return isSeparator(prev_s) ||// match FOLLOW a separator
-           (curr_s != subject_lw[pos] && prev_s == subject_lw[pos - 1]);// match is Capital in camelCase (preceded by lowercase)
+           curr_s != subject_lw[pos] && prev_s == subject_lw[pos - 1];// match is Capital in camelCase (preceded by lowercase)
 }
 
 bool isWordEnd(int pos, const CandidateString &subject, const CandidateString &subject_lw, int len) {
@@ -254,7 +254,7 @@ bool isWordEnd(int pos, const CandidateString &subject, const CandidateString &s
     const auto curr_s = subject[pos];
     const auto next_s = subject[pos + 1];
     return isSeparator(next_s) ||// match IS FOLLOWED BY a separator
-           (curr_s == subject_lw[pos] && next_s != subject_lw[pos + 1]);// match is lowercase, followed by uppercase
+           curr_s == subject_lw[pos] && next_s != subject_lw[pos + 1];// match is lowercase, followed by uppercase
 }
 
 bool isSeparator(char c) {

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -52,7 +52,7 @@ Score scorer_score(const CandidateString &string, const Element &query, const Op
         return 0;
     }
     const auto string_lw = ToLower(string);
-    auto score = computeScore(string, string_lw, options.preparedQuery);
+    const auto score = computeScore(string, string_lw, options.preparedQuery);
     return ceil(score);
 }
 
@@ -61,8 +61,8 @@ Score scorer_score(const CandidateString &string, const Element &query, const Op
 // Are all (non optional)characters of query in subject, in proper order ?
 //
 bool isMatch(const CandidateString &subject, const Element &query_lw, const Element &query_up) {
-    int m = subject.size();
-    int n = query_lw.size();
+    const int m = subject.size();
+    const int n = query_lw.size();
 
     if ((m == 0) || n > m) {
         return false;
@@ -104,14 +104,14 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
     const auto &query = preparedQuery.query;
     const auto &query_lw = preparedQuery.query_lw;
 
-    int m = subject.size();
-    int n = query.size();
+    const int m = subject.size();
+    const int n = query.size();
 
     //----------------------------
     // Abbreviations sequence
 
-    auto acro = scoreAcronyms(subject, subject_lw, query, query_lw);
-    auto acro_score = acro.score;
+    const auto acro = scoreAcronyms(subject, subject_lw, query, query_lw);
+    const auto acro_score = acro.score;
 
     // Whole query is abbreviation ?
     // => use that as score
@@ -123,7 +123,7 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
     // Exact Match ?
     // => use that as score
 
-    auto pos = subject_lw.find(query_lw);
+    const auto pos = subject_lw.find(query_lw);
     if (pos != std::string::npos) {
         return scoreExactMatch(subject, subject_lw, query, query_lw, pos, n, m);
     }
@@ -137,9 +137,9 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
     // Init
     vector<Score> score_row(n, 0);
     vector<Score> csc_row(n, 0);
-    auto sz = scoreSize(n, m);
+    const auto sz = scoreSize(n, m);
 
-    auto miss_budget = ceil(miss_coeff * n) + 5;
+    const auto miss_budget = ceil(miss_coeff * n) + 5;
     auto miss_left = miss_budget;
     bool csc_should_rebuild = true;
 
@@ -191,14 +191,13 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
 
             //Compute a tentative match
             if (query_lw[j] == si_lw) {
-
-                auto start = isWordStart(i, subject, subject_lw);
+                const auto start = isWordStart(i, subject, subject_lw);
 
                 // Forward search for a sequence of consecutive char
                 csc_score = csc_diag > 0 ? csc_diag : scoreConsecutives(subject, subject_lw, query, query_lw, i, j, start);
 
                 // Determine bonus for matching A[i] with B[j]
-                Score align = score_diag + scoreCharacter(i, j, start, acro_score, csc_score);
+                const auto align = score_diag + scoreCharacter(i, j, start, acro_score, csc_score);
 
                 //Are we better using this match or taking the best gap (currently stored in score)?
                 if (align > score) {
@@ -227,7 +226,7 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
     }
 
     // get hightest score so far
-    auto score = score_row[n - 1];
+    const auto score = score_row[n - 1];
     return score * sz;
 }
 
@@ -344,12 +343,13 @@ Score scoreCharacter(int i, int j, bool start, Score acro_score, Score csc_score
 // Forward search for a sequence of consecutive character.
 //
 Score scoreConsecutives(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int i, int j, bool startOfWord) {
-    auto m = subject.size();
-    auto n = query.size();
+    const auto m = subject.size();
+    const auto n = query.size();
 
     int mi = m - i;
     int nj = n - j;
     int k = mi < nj ? mi : nj;
+    const auto k = mi < nj ? mi : nj;
 
     int sameCase = 0;
     int sz = 0;//sz will be one more than the last qi is sj
@@ -400,7 +400,7 @@ Score scoreExactMatch(const CandidateString &subject, const CandidateString &sub
     // - Testing 2 instances is somewhere between testing only one and testing every instances.
 
     if (!start) {
-        auto pos2 = subject_lw.find(query_lw, pos + 1);
+        const auto pos2 = subject_lw.find(query_lw, pos + 1);
         if (pos2 != string::npos) {
             start = isWordStart(pos2, subject, subject_lw);
             if (start) {
@@ -436,8 +436,8 @@ Score scoreExactMatch(const CandidateString &subject, const CandidateString &sub
 AcronymResult emptyAcronymResult(static_cast<Score>(0), static_cast<float>(0.1), static_cast<int>(0));
 
 AcronymResult scoreAcronyms(CandidateString subject, CandidateString subject_lw, Element query, Element query_lw) {
-    auto m = subject.size();
-    auto n = query.size();
+    const auto m = subject.size();
+    const auto n = query.size();
 
     //a single char is not an acronym
     if (m <= 1 || n <= 1) {
@@ -499,7 +499,7 @@ AcronymResult scoreAcronyms(CandidateString subject, CandidateString subject_lw,
     // Acronym are scored as start-of-word
     // Unless the acronym is a 1:1 match with candidate then it is upgraded to full-word.
     bool fullWord = count == n ? isAcronymFullWord(subject, subject_lw, query, count) : false;
-    auto score = scorePattern(count, n, sameCase, true, fullWord);
+    const auto score = scorePattern(count, n, sameCase, true, fullWord);
 
     return AcronymResult(score, Score(sumPos) / count, count + sepCount);
 }
@@ -514,9 +514,9 @@ AcronymResult scoreAcronyms(CandidateString subject, CandidateString subject_lw,
 // This method check for (b) assuming (a) has been checked before entering.
 
 bool isAcronymFullWord(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, int nbAcronymInQuery) {
-    int m = subject.size();
-    int n = query.size();
-    int count = 0;
+    const int m = subject.size();
+    const int n = query.size();
+    auto count = 0;
 
     // Heuristic:
     // Assume one acronym every (at most) 12 character on average

--- a/src/tree.h
+++ b/src/tree.h
@@ -8,7 +8,7 @@ const std::optional<Napi::Array> getChildren(Napi::Object const &jsTree, string 
     Napi::Array childrenArray;
 
     // determine if it has children
-    bool hasChildren = false;
+    auto hasChildren = false;
     if (jsTree.HasOwnProperty(childrenKey)) {
         const auto childrenRaw = jsTree.Get(childrenKey);
         if (childrenRaw.IsArray()) {
@@ -54,7 +54,7 @@ struct Tree {
     /** 1st argument is a single object */
     void makeEntriesArray(Napi::Object const &jsTree, size_t const level, int32_t const iEntry = -1) {
         // get the current data
-        CandidateString data = jsTree.Get(dataKey).ToString().Utf8Value();
+        const auto data = jsTree.Get(dataKey).ToString().Utf8Value();
         entriesArray.push_back(CandidateObject(data, level, iEntry));
 
         // add children if any

--- a/src/tree.h
+++ b/src/tree.h
@@ -4,13 +4,13 @@
 #include "common.h"
 
 /** Get the children of a jsTree (Napi::Object) */
-std::optional<Napi::Array> getChildren(Napi::Object const &jsTree, string const &childrenKey) {
+const std::optional<Napi::Array> getChildren(Napi::Object const &jsTree, string const &childrenKey) {
     Napi::Array childrenArray;
 
     // determine if it has children
     bool hasChildren = false;
     if (jsTree.HasOwnProperty(childrenKey)) {
-        auto childrenRaw = jsTree.Get(childrenKey);
+        const auto childrenRaw = jsTree.Get(childrenKey);
         if (childrenRaw.IsArray()) {
             childrenArray = childrenRaw.As<Napi::Array>();
             if (childrenArray.Length() != 0) {


### PR DESCRIPTION
- Add and run clang-tidy
- Add auto where possible
- Add const where possible
- Build on C++20 on all platforms
- Test on old platforms

<details>
<summary>Benchmarks before and after</summary>

TwoLetter#Keybased#Filter seems to be faster now. In other benchmarks, there is no meaningful performance difference. Multiple benchmarks give different results.

Benchmarks after:

```
> fuzzaldrin-plus-fast@1.1.0 benchmark C:\Users\aminy\Documents\GitHub\JavaScript\@atom-ide-community\fuzzaldrin-plus-fast
> npm run benchmark:small && npm run benchmark:regular && npm run benchmark:large


> fuzzaldrin-plus-fast@1.1.0 benchmark:small
> node benchmark/benchmark-small.js

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 1 ms
length 100 100

====== Running test - query:npm ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 4 ms
length 55 100

====== Running test - query:node ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 1 ms
length 100 100

====== Running test - query:grunt ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 1 ms
length 33 100

====== Running test - query:html ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 1 ms
length 10 100

====== Running test - query:doc ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 4 ms
length 87 100

====== Running test - query:cli ======
Elapsed time - fuzzaldrin-plus-fast: 1 ms vs. fuzzaldrin-plus: 2 ms
length 57 100

====== Running test - query:js ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 0 ms
length 60 100

====== Running test - query:jas ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 1 ms
length 19 100

====== Running test - query:mine ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 2 ms
length 65 100

====== Running test - query:stream ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 1 ms
length 19 100


> fuzzaldrin-plus-fast@1.1.0 benchmark:regular
> node benchmark/benchmark.js

====== Running test - query:index ======
Elapsed time - fuzzaldrin-plus-fast: 30 ms vs. fuzzaldrin-plus: 44 ms
length 6168 66672

====== Running test - query:indx ======
Elapsed time - fuzzaldrin-plus-fast: 30 ms vs. fuzzaldrin-plus: 54 ms
length 6192 66672

====== Running test - query:walkdr ======
Elapsed time - fuzzaldrin-plus-fast: 26 ms vs. fuzzaldrin-plus: 16 ms
length 504 66672
====== fuzzaldrin-plus-fast is SLOWER

====== Running test - query:node ======
Elapsed time - fuzzaldrin-plus-fast: 48 ms vs. fuzzaldrin-plus: 68 ms
length 65136 66672

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 47 ms vs. fuzzaldrin-plus: 66 ms
length 65208 66672

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 47 ms vs. fuzzaldrin-plus: 50 ms
length 65208 66672

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 48 ms vs. fuzzaldrin-plus: 60 ms
length 65208 66672

====== Running test - query:ndem ======
Elapsed time - fuzzaldrin-plus-fast: 52 ms vs. fuzzaldrin-plus: 236 ms
length 65124 66672

Matching 66672 results for 'index' took 297ms (Prepare in advance)
Matching 66672 results for 'index' took 294ms (cache)
Matching 66672 results for 'index' took 84ms (legacy)

> fuzzaldrin-plus-fast@1.1.0 benchmark:large
> node benchmark/benchmark-large.js

TwoLetter#legacy: 11.107s
TwoLetter#fuzzaldrin-plus-fast#DirectFilter: 3.201s
TwoLetter#fuzzaldrin-plus-fast#setCandidates#filter: 478.81ms
======
ThreeLetter#legacy: 8.747s
ThreeLetter#fuzzaldrin-plus-fast#DirectFilter: 3.443s
ThreeLetter#fuzzaldrin-plus-fast#setCandidates#filter: 451.884ms
======
TwoLetter#Keybased#Filter: 4.180s
ThreeLetter#Keybased#Filter: 4.878s
======
setCandidates: 240.143ms
TwoLetter#Filter: 468.944ms
ThreeLetter#Filter: 451.256ms
======
setCandidates#Keybased: 246.632ms
TwoLetter#Keybased#Filter: 471.995ms
ThreeLetter#Keybased#Filter: 443.108ms
```
Benchmarks before:
```
> npm run benchmark:small && npm run benchmark:regular && npm run benchmark:large


> fuzzaldrin-plus-fast@1.1.0 benchmark:small
> node benchmark/benchmark-small.js

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 1 ms
length 100 100

====== Running test - query:npm ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 4 ms
length 55 100

====== Running test - query:node ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 2 ms
length 100 100

====== Running test - query:grunt ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 0 ms
length 33 100

====== Running test - query:html ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 0 ms
length 10 100

====== Running test - query:doc ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 4 ms
length 87 100

====== Running test - query:cli ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 2 ms
length 57 100

====== Running test - query:js ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 0 ms
length 60 100

====== Running test - query:jas ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 1 ms
length 19 100

====== Running test - query:mine ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 2 ms
length 65 100

====== Running test - query:stream ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 1 ms
length 19 100


> fuzzaldrin-plus-fast@1.1.0 benchmark:regular
> node benchmark/benchmark.js

====== Running test - query:index ======
Elapsed time - fuzzaldrin-plus-fast: 29 ms vs. fuzzaldrin-plus: 45 ms
length 6168 66672

====== Running test - query:indx ======
Elapsed time - fuzzaldrin-plus-fast: 29 ms vs. fuzzaldrin-plus: 51 ms
length 6192 66672

====== Running test - query:walkdr ======
Elapsed time - fuzzaldrin-plus-fast: 27 ms vs. fuzzaldrin-plus: 16 ms
length 504 66672
====== fuzzaldrin-plus-fast is SLOWER

====== Running test - query:node ======
Elapsed time - fuzzaldrin-plus-fast: 50 ms vs. fuzzaldrin-plus: 68 ms
length 65136 66672

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 51 ms vs. fuzzaldrin-plus: 60 ms
length 65208 66672

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 49 ms vs. fuzzaldrin-plus: 52 ms
length 65208 66672

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 48 ms vs. fuzzaldrin-plus: 54 ms
length 65208 66672

====== Running test - query:ndem ======
Elapsed time - fuzzaldrin-plus-fast: 51 ms vs. fuzzaldrin-plus: 242 ms
length 65124 66672

Matching 66672 results for 'index' took 298ms (Prepare in advance)
Matching 66672 results for 'index' took 291ms (cache)
Matching 66672 results for 'index' took 89ms (legacy)

> fuzzaldrin-plus-fast@1.1.0 benchmark:large
> node benchmark/benchmark-large.js

TwoLetter#legacy: 11.255s
TwoLetter#fuzzaldrin-plus-fast#DirectFilter: 3.268s
TwoLetter#fuzzaldrin-plus-fast#setCandidates#filter: 485.822ms
======
ThreeLetter#legacy: 8.887s
ThreeLetter#fuzzaldrin-plus-fast#DirectFilter: 3.281s
ThreeLetter#fuzzaldrin-plus-fast#setCandidates#filter: 446.293ms
======
TwoLetter#Keybased#Filter: 3.857s
ThreeLetter#Keybased#Filter: 4.677s
======
setCandidates: 235.303ms
TwoLetter#Filter: 646.962ms
ThreeLetter#Filter: 459.873ms
======
setCandidates#Keybased: 233.968ms
TwoLetter#Keybased#Filter: 638.149ms
ThreeLetter#Keybased#Filter: 461.798ms
```

</details>