### PR TITLE
Improve performance and tidiness

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 ---
-Checks:          '*, -cppcoreguidelines-init-variables, -modernize-return-braced-init-list, -misc-unused-parameters, -misc-non-private-member-variables-in-classes, -llvmlibc-*, -llvm-header-guard, -llvm-include-order, -modernize-use-trailing-return-type, -readability-convert-member-functions-to-static, -fuchsia-default-arguments-declarations, -fuchsia-default-arguments-calls, -*-uppercase-literal-suffix, -fuchsia-overloaded-operator, -google-build-using-namespace, -google-global-names-in-headers'
+Checks:          '*, -cppcoreguidelines-init-variables, -modernize-return-braced-init-list, -misc-unused-parameters, -misc-non-private-member-variables-in-classes, -llvmlibc-*, -llvm-header-guard, -llvm-include-order, -modernize-use-trailing-return-type, -readability-const-return-type, -readability-avoid-const-params-in-decls, -readability-convert-member-functions-to-static, -fuchsia-default-arguments-declarations, -fuchsia-default-arguments-calls, -*-uppercase-literal-suffix, -fuchsia-overloaded-operator, -google-build-using-namespace, -google-global-names-in-headers'
 HeaderFilterRegex: '.*'
 FormatStyle:     none

--- a/src/common.h
+++ b/src/common.h
@@ -12,7 +12,7 @@
 
 using namespace std;
 
-static const size_t kMaxThreads = 16;
+constexpr size_t kMaxThreads = 16;
 
 #ifdef ENABLE_DEBUG
 // Safe string class that logs error when index is accessed outside the string.

--- a/src/common.h
+++ b/src/common.h
@@ -83,7 +83,7 @@ extern Element ToUpper(const Element &s);
 extern bool isMatch(const CandidateString &subject, const Element &query_lw, const Element &query_up);
 extern bool isWordStart(const int pos, const CandidateString &subject, const CandidateString &subject_lw);
 extern Score scoreCharacter(const int i, const int j, const bool start, const Score acro_score, const Score csc_score);
-extern Score scoreConsecutives(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int i, int j, const bool startOfWord);
+extern Score scoreConsecutives(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, unsigned i, unsigned j, const bool startOfWord);
 extern AcronymResult scoreAcronyms(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw);
 
 extern Score computeScore(const CandidateString &subject, const CandidateString &subject_lw, const PreparedQuery &preparedQuery);

--- a/src/common.h
+++ b/src/common.h
@@ -84,7 +84,7 @@ extern bool isMatch(const CandidateString &subject, const Element &query_lw, con
 extern bool isWordStart(const int pos, const CandidateString &subject, const CandidateString &subject_lw);
 extern Score scoreCharacter(const int i, const int j, const bool start, const Score acro_score, const Score csc_score);
 extern Score scoreConsecutives(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int i, int j, const bool startOfWord);
-extern AcronymResult scoreAcronyms(const CandidateString subject, const CandidateString subject_lw, const Element query, const Element query_lw);
+extern AcronymResult scoreAcronyms(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw);
 
 extern Score computeScore(const CandidateString &subject, const CandidateString &subject_lw, const PreparedQuery &preparedQuery);
 

--- a/src/common.h
+++ b/src/common.h
@@ -81,7 +81,7 @@ extern Element ToLower(const Element &s);
 extern Element ToUpper(const Element &s);
 
 extern bool isMatch(const CandidateString &subject, const Element &query_lw, const Element &query_up);
-extern bool isWordStart(const int pos, const CandidateString &subject, const CandidateString &subject_lw);
+extern bool isWordStart(const size_t pos, const CandidateString &subject, const CandidateString &subject_lw);
 extern Score scoreCharacter(const int i, const int j, const bool start, const Score acro_score, const Score csc_score);
 extern Score scoreConsecutives(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, unsigned i, unsigned j, const bool startOfWord);
 extern AcronymResult scoreAcronyms(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw);

--- a/src/common.h
+++ b/src/common.h
@@ -92,7 +92,7 @@ extern Score scorer_score(const CandidateString &string, const Element &query, c
 extern Score scoreSize(Score n, Score m);
 
 extern Score path_scorer_score(const CandidateString &string, const Element &query, const Options &options);
-extern int countDir(const CandidateString &path, int end, char pathSeparator);
+extern int countDir(const CandidateString &path, const size_t end, const char pathSeparator);
 extern CandidateString getExtension(const CandidateString &str);
 
 extern const std::vector<CandidateIndex> filter(const vector<std::vector<CandidateString>> &candidates, const Element &query, const Options &options);

--- a/src/common.h
+++ b/src/common.h
@@ -50,7 +50,7 @@ struct PreparedQuery {
     Element ext;
     std::set<char> charCodes{};
 
-    PreparedQuery(const Element &q, char pathSeparator);
+    PreparedQuery(const Element &q, const char pathSeparator);
 };
 
 struct Options {

--- a/src/common.h
+++ b/src/common.h
@@ -12,7 +12,7 @@
 
 using namespace std;
 
-const size_t kMaxThreads = 16;
+static const size_t kMaxThreads = 16;
 
 #ifdef ENABLE_DEBUG
 // Safe string class that logs error when index is accessed outside the string.

--- a/src/common.h
+++ b/src/common.h
@@ -74,7 +74,7 @@ struct AcronymResult {
     float pos;
     int count;
 
-    AcronymResult(Score s, float p, int c) : score(s), pos(p), count(c) {}
+    AcronymResult(Score s, float p, int c) noexcept : score(s), pos(p), count(c) {}
 };
 
 extern Element ToLower(const Element &s);

--- a/src/common.h
+++ b/src/common.h
@@ -81,15 +81,15 @@ extern Element ToLower(const Element &s);
 extern Element ToUpper(const Element &s);
 
 extern bool isMatch(const CandidateString &subject, const Element &query_lw, const Element &query_up);
-extern bool isWordStart(int pos, const CandidateString &subject, const CandidateString &subject_lw);
-extern Score scoreCharacter(int i, int j, bool start, Score acro_score, Score csc_score);
-extern Score scoreConsecutives(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int i, int j, bool startOfWord);
-extern AcronymResult scoreAcronyms(CandidateString subject, CandidateString subject_lw, Element query, Element query_lw);
+extern bool isWordStart(const int pos, const CandidateString &subject, const CandidateString &subject_lw);
+extern Score scoreCharacter(const int i, const int j, const bool start, const Score acro_score, const Score csc_score);
+extern Score scoreConsecutives(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int i, int j, const bool startOfWord);
+extern AcronymResult scoreAcronyms(const CandidateString subject, const CandidateString subject_lw, const Element query, const Element query_lw);
 
 extern Score computeScore(const CandidateString &subject, const CandidateString &subject_lw, const PreparedQuery &preparedQuery);
 
 extern Score scorer_score(const CandidateString &string, const Element &query, const Options &options);
-extern Score scoreSize(Score n, Score m);
+extern Score scoreSize(const Score n, const Score m);
 
 extern Score path_scorer_score(const CandidateString &string, const Element &query, const Options &options);
 extern int countDir(const CandidateString &path, const size_t end, const char pathSeparator);

--- a/src/filter.cc
+++ b/src/filter.cc
@@ -27,13 +27,16 @@ void filter_internal(const std::vector<CandidateString> &candidates,
   CandidateScorePriorityQueue &results) {
     for (size_t i = 0, len = candidates.size(); i < len; i++) {
         const auto &candidate = candidates[i];
-        if (candidate.empty()) continue;
+        if (candidate.empty()) {
+            continue;
+        }
         const auto scoreProvider = options.usePathScoring ? path_scorer_score : scorer_score;
         auto score = scoreProvider(candidate, query, options);
         if (score > 0) {
             results.emplace(score, start_index + i);
-            if (results.size() > max_results)
+            if (results.size() > max_results) {
                 results.pop();
+            }
         }
     }
 }
@@ -88,8 +91,9 @@ const std::vector<CandidateIndex> filter(const vector<std::vector<CandidateStrin
         while (!results[i].empty()) {
             top_k.emplace(results[i].top());
             results[i].pop();
-            if (top_k.size() > max_results)
+            if (top_k.size() > max_results) {
                 top_k.pop();
+            }
         }
     }
     return sort_priority_queue(top_k);

--- a/src/fuzzaldrin.cc
+++ b/src/fuzzaldrin.cc
@@ -60,7 +60,7 @@ void Fuzzaldrin::SetCandidates(const vector<CandidateObject> &candidates) {
             chunk_size++;
         }
         for (auto j = cur_start; j < cur_start + chunk_size; j++) {
-            candidates_[i].push_back(candidates[j].data);// different
+            candidates_[i].push_back(candidates[j].data);// different // TODO copy
         }
         cur_start += chunk_size;
     }
@@ -77,11 +77,11 @@ Napi::Value Fuzzaldrin::FilterTree(const Napi::CallbackInfo &info) {
         Napi::TypeError::New(info.Env(), "Invalid arguments").ThrowAsJavaScriptException();
         return Napi::Array::New(info.Env());
     }
-    auto const jsTreeArray = info[0].As<Napi::Array>();
-    std::string query = info[1].As<Napi::String>();
+    const auto &jsTreeArray = info[0].As<Napi::Array>();
+    const std::string &query = info[1].As<Napi::String>();
 
-    string const dataKey = info[2].As<Napi::String>();
-    string const childrenKey = info[3].As<Napi::String>();
+    const string &dataKey = info[2].As<Napi::String>();
+    const string &childrenKey = info[3].As<Napi::String>();
 
     const size_t maxResults = info[4].As<Napi::Number>().Uint32Value();
     const bool usePathScoring = info[5].As<Napi::Boolean>();
@@ -92,8 +92,8 @@ Napi::Value Fuzzaldrin::FilterTree(const Napi::CallbackInfo &info) {
     SetCandidates(tree.entriesArray);
 
     // create options
-    const Options options(query, maxResults, usePathScoring, useExtensionBonus);
-    const auto matches = filter(candidates_, query, options);
+    const auto options = Options(query, maxResults, usePathScoring, useExtensionBonus);
+    const auto &matches = filter(candidates_, query, options);
 
     // filter
     auto filteredCandidateObjects = Napi::Array::New(info.Env());// array of candidate objects (with their address in index and level)

--- a/src/fuzzaldrin.cc
+++ b/src/fuzzaldrin.cc
@@ -98,7 +98,7 @@ Napi::Value Fuzzaldrin::FilterTree(const Napi::CallbackInfo &info) {
     // filter
     auto filteredCandidateObjects = Napi::Array::New(info.Env());// array of candidate objects (with their address in index and level)
     for (uint32_t i = 0, len = matches.size(); i < len; i++) {
-        auto entry = tree.entriesArray[matches[i]];//
+        auto &entry = tree.entriesArray[matches[i]];//
 
         // create {data, index, level}
         auto obj = Napi::Object::New(info.Env());

--- a/src/fuzzaldrin.cc
+++ b/src/fuzzaldrin.cc
@@ -47,7 +47,7 @@ Napi::Value Fuzzaldrin::SetCandidates(const Napi::CallbackInfo &info) {
     return Napi::Boolean();
 }
 
-void Fuzzaldrin::SetCandidates(vector<CandidateObject> const &candidates) {
+void Fuzzaldrin::SetCandidates(const vector<CandidateObject> &candidates) {
     const auto N = candidates.size();// different
     const auto num_chunks = N < 1000 * kMaxThreads ? N / 1000 + 1 : kMaxThreads;
     candidates_.clear();
@@ -83,16 +83,16 @@ Napi::Value Fuzzaldrin::FilterTree(const Napi::CallbackInfo &info) {
     string const dataKey = info[2].As<Napi::String>();
     string const childrenKey = info[3].As<Napi::String>();
 
-    size_t maxResults = info[4].As<Napi::Number>().Uint32Value();
-    bool usePathScoring = info[5].As<Napi::Boolean>();
-    bool useExtensionBonus = info[6].As<Napi::Boolean>();
+    const size_t maxResults = info[4].As<Napi::Number>().Uint32Value();
+    const bool usePathScoring = info[5].As<Napi::Boolean>();
+    const bool useExtensionBonus = info[6].As<Napi::Boolean>();
 
     // create Tree and set candidates
     auto tree = Tree(jsTreeArray, dataKey, childrenKey);
     SetCandidates(tree.entriesArray);
 
     // create options
-    Options options(query, maxResults, usePathScoring, useExtensionBonus);
+    const Options options(query, maxResults, usePathScoring, useExtensionBonus);
     const auto matches = filter(candidates_, query, options);
 
     // filter

--- a/src/matcher.cc
+++ b/src/matcher.cc
@@ -32,17 +32,19 @@ std::vector<size_t> computeMatch(const CandidateString &subject, const Candidate
     vector<Score> csc_row(n, 0);
 
     // Directions constants
-    enum Direction { STOP,
+    enum Direction {
+        STOP,
         UP,
         LEFT,
-        DIAGONAL };
+        DIAGONAL
+    };
 
     // Traceback matrix
     std::vector<Direction> trace(m * n, STOP);
     auto pos = -1;
 
     auto i = -1;
-    while (++i < m) {//foreach char si of subject
+    while (++i < m) {//foreach char is of subject
         Score score = 0;
         Score score_up = 0;
         Score csc_diag = 0;
@@ -140,8 +142,9 @@ std::vector<size_t> basenameMatch(const CandidateString &subject, const Candidat
     auto basePos = subject.rfind(pathSeparator, end);
 
     // If no PathSeparator, no base path exist.
-    if (basePos == std::string::npos)
+    if (basePos == std::string::npos) {
         return std::vector<size_t>();
+    }
 
     // Get the number of folder in query
     auto depth = preparedQuery.depth;
@@ -149,8 +152,9 @@ std::vector<size_t> basenameMatch(const CandidateString &subject, const Candidat
     // Get that many folder from subject
     while (depth-- > 0) {
         basePos = subject.rfind(pathSeparator, basePos - 1);
-        if (basePos == std::string::npos)// consumed whole subject ?
+        if (basePos == std::string::npos) {// consumed whole subject ?
             return std::vector<size_t>();
+        }
     }
 
     // Get basePath match
@@ -171,8 +175,12 @@ std::vector<size_t> mergeMatches(const std::vector<size_t> &a, const std::vector
     const auto m = a.size();
     const auto n = b.size();
 
-    if (n == 0) return a;
-    if (m == 0) return b;
+    if (n == 0) {
+        return a;
+    }
+    if (m == 0) {
+        return b;
+    }
 
     auto i = -1;
     auto j = 0;
@@ -183,14 +191,16 @@ std::vector<size_t> mergeMatches(const std::vector<size_t> &a, const std::vector
         auto ai = a[i];
 
         while (bj <= ai && ++j < n) {
-            if (bj < ai)
+            if (bj < ai) {
                 out.push_back(bj);
+            }
             bj = b[j];
         }
         out.push_back(ai);
     }
-    while (j < n)
+    while (j < n) {
         out.push_back(b[j++]);
+    }
     return out;
 }
 

--- a/src/matcher.cc
+++ b/src/matcher.cc
@@ -19,6 +19,7 @@ std::vector<size_t> computeMatch(const CandidateString &subject, const Candidate
     const auto &query = preparedQuery.query;
     const auto &query_lw = preparedQuery.query_lw;
 
+    // TODO making these two auto breaks the code. There are a lot of narrowing conversions in this file
     const int m = subject.size();
     const int n = query.size();
 
@@ -130,7 +131,7 @@ std::vector<size_t> computeMatch(const CandidateString &subject, const Candidate
 
 std::vector<size_t> basenameMatch(const CandidateString &subject, const CandidateString &subject_lw, const PreparedQuery &preparedQuery, char pathSeparator) {
     // Skip trailing slashes
-    int end = subject.size() - 1;
+    auto end = subject.size() - 1;
     while (subject[end] == pathSeparator) {
         end--;
     }
@@ -167,8 +168,8 @@ std::vector<size_t> basenameMatch(const CandidateString &subject, const Candidat
 // (Assume sequences are sorted, matches are sorted by construction.)
 //
 std::vector<size_t> mergeMatches(const std::vector<size_t> &a, const std::vector<size_t> &b) {
-    const int m = a.size();
-    const int n = b.size();
+    const auto m = a.size();
+    const auto n = b.size();
 
     if (n == 0) return a;
     if (m == 0) return b;
@@ -206,9 +207,9 @@ std::vector<size_t> matcher_match(const CandidateString &string, const Element &
 }
 
 void get_wrap(const CandidateString &string, const Element &query, const Options &options, std::string *out) {
-    const std::string tagClass = "highlight";
-    const auto tagOpen = "<strong class=\"" + tagClass + "\">";
-    const std::string tagClose = "</strong>";
+    const auto tagClass = "highlight"s;
+    const auto tagOpen = "<strong class=\""s + tagClass + "\">"s;
+    const auto tagClose = "</strong>"s;
 
     if (string == query) {
         *out = tagOpen + string + tagClose;

--- a/src/matcher.cc
+++ b/src/matcher.cc
@@ -32,7 +32,7 @@ std::vector<size_t> computeMatch(const CandidateString &subject, const Candidate
     vector<Score> csc_row(n, 0);
 
     // Directions constants
-    enum Direction {
+    enum class Direction {
         STOP,
         UP,
         LEFT,
@@ -40,7 +40,7 @@ std::vector<size_t> computeMatch(const CandidateString &subject, const Candidate
     };
 
     // Traceback matrix
-    std::vector<Direction> trace(m * n, STOP);
+    std::vector<Direction> trace(m * n, Direction::STOP);
     auto pos = -1;
 
     auto i = -1;
@@ -74,16 +74,16 @@ std::vector<size_t> computeMatch(const CandidateString &subject, const Candidate
 
             // In case of equality, moving UP get us closer to the start of the candidate string.
             if (score > score_up) {
-                move = LEFT;
+                move = Direction::LEFT;
             } else {
                 score = score_up;
-                move = UP;
+                move = Direction::UP;
             }
 
             // Only take alignment if it's the absolute best option.
             if (align > score) {
                 score = align;
-                move = DIAGONAL;
+                move = Direction::DIAGONAL;
             } else {
                 // If we do not take this character, break consecutive sequence.
                 // (when consecutive is 0, it'll be recomputed)
@@ -92,7 +92,7 @@ std::vector<size_t> computeMatch(const CandidateString &subject, const Candidate
 
             score_row[j] = score;
             csc_row[j] = csc_score;
-            trace[++pos] = score > 0 ? move : STOP;
+            trace[++pos] = score > 0 ? move : Direction::STOP;
         }
     }
 
@@ -108,15 +108,15 @@ std::vector<size_t> computeMatch(const CandidateString &subject, const Candidate
 
     while (backtrack && i >= 0 && j >= 0) {
         switch (trace[pos]) {
-        case UP:
+        case Direction::UP:
             i--;
             pos -= n;
             break;
-        case LEFT:
+        case Direction::LEFT:
             j--;
             pos--;
             break;
-        case DIAGONAL:
+        case Direction::DIAGONAL:
             matches.push_back(i + offset);
             j--;
             i--;

--- a/src/matcher.cc
+++ b/src/matcher.cc
@@ -230,7 +230,7 @@ void get_wrap(const CandidateString &string, const Element &query, const Options
     auto matchPositions = matcher_match(string, query, options);
 
     // If no match return as is
-    if (matchPositions.size() == 0) {
+    if (matchPositions.empty()) {
         *out = string;
         return;
     }

--- a/src/path_scorer.cc
+++ b/src/path_scorer.cc
@@ -96,7 +96,7 @@ Score scorePath(const CandidateString &subject, const CandidateString &subject_l
     // A penalty based on the size of the basePath is applied to fullPathScore
     // That way, more focused basePath match can overcome longer directory path.
 
-    const Score alpha = 0.5 * tau_depth / (tau_depth + countDir(subject, end + 1, options.pathSeparator));
+    const Score alpha = (0.5 * tau_depth) / (tau_depth + countDir(subject, end + 1, options.pathSeparator));
     return alpha * basePathScore + (1 - alpha) * fullPathScore * scoreSize(0, file_coeff * fileLength);
 }
 
@@ -114,12 +114,12 @@ int countDir(const CandidateString &path, const size_t end, const char pathSepar
     auto i = -1;
 
     //skip slash at the start so `foo/bar` and `/foo/bar` have the same depth.
-    while (++i < end && path[i] == pathSeparator) { }
+    while (++i < end && path[i] == pathSeparator) {}
 
     while (++i < end) {
         if (path[i] == pathSeparator) {
             count++;//record first slash, but then skip consecutive ones
-            while (++i < end && path[i] == pathSeparator) { }
+            while (++i < end && path[i] == pathSeparator) {}
         }
     }
 

--- a/src/path_scorer.cc
+++ b/src/path_scorer.cc
@@ -3,10 +3,10 @@
 namespace {
 
 // Directory depth at which the full path influence is halved.
-size_t tau_depth = 20;
+const size_t tau_depth = 20;
 
 // Full path is also penalized for length of basename. This adjust a scale factor for that penalty.
-Score file_coeff = 2.5;
+const Score file_coeff = 2.5;
 
 };// namespace
 
@@ -56,7 +56,7 @@ Score scorePath(const CandidateString &subject, const CandidateString &subject_l
     // {preparedQuery, useExtensionBonus, pathSeparator} = options
 
     // Skip trailing slashes
-    int end = subject.size() - 1;
+    auto end = subject.size() - 1;
     while (subject[end] == options.pathSeparator) {
         end--;
     }
@@ -105,7 +105,7 @@ Score scorePath(const CandidateString &subject, const CandidateString &subject_l
 // Count number of folder in a path.
 // (consecutive slashes count as a single directory)
 //
-int countDir(const CandidateString &path, int end, char pathSeparator) {
+int countDir(const CandidateString &path, const size_t end, const char pathSeparator) {
     if (end < 1) {
         return 0;
     }

--- a/src/path_scorer.cc
+++ b/src/path_scorer.cc
@@ -16,13 +16,13 @@ extern Score scorePath(const CandidateString &subject, const CandidateString &su
 extern Score getExtensionScore(const CandidateString &candidate, const CandidateString &ext, int startPos, int endPos, int maxDepth);
 
 Element ToLower(const Element &s) {
-    auto snew = s;
+    Element /* copy */ snew = s;
     std::transform(s.begin(), s.end(), snew.begin(), ::tolower);
     return snew;
 }
 
 Element ToUpper(const Element &s) {
-    auto snew = s;
+    Element /* copy */ snew = s;
     std::transform(s.begin(), s.end(), snew.begin(), ::toupper);
     return snew;
 }

--- a/src/query.cc
+++ b/src/query.cc
@@ -3,7 +3,7 @@
 extern Element coreChars(Element query);
 extern std::set<char> getCharCodes(const Element &str);
 
-PreparedQuery::PreparedQuery(const Element &q, char pathSeparator) : query(q), query_lw(ToLower(q)), core(coreChars(q)), core_lw(ToLower(core)), core_up(ToUpper(core)) {
+PreparedQuery::PreparedQuery(const Element &q, const char pathSeparator) : query(q), query_lw(ToLower(q)), core(coreChars(q)), core_lw(ToLower(core)), core_up(ToUpper(core)) {
     depth = countDir(query, query.size(), pathSeparator);
     ext = getExtension(query_lw);
     charCodes = getCharCodes(query_lw);

--- a/src/query.cc
+++ b/src/query.cc
@@ -27,7 +27,8 @@ std::set<char> getCharCodes(const Element &str) {
     auto i = -1;
 
     // create map
-    while (++i < len)
+    while (++i < len) {
         charCodes.insert(str[i]);
+    }
     return charCodes;
 }

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -436,14 +436,14 @@ Score scoreExactMatch(const CandidateString &subject, const CandidateString &sub
         ++i;
     }
 
-    const auto end = static_cast<int>(isWordEnd(pos + n - 1u, subject, subject_lw, m));
+    const auto end = isWordEnd(pos + n - 1u, subject, subject_lw, m);
 
     Score baseNameStart = 1.0;
     if (start && pos > 0 && (subject[pos - 1] == '/' || subject[pos - 1] == '\\')) {
         baseNameStart = static_cast<Score>(1.1);
     }
 
-    return scoreExact(n, m, baseNameStart * scorePattern(n, n, sameCase, start, end != 0), pos);
+    return scoreExact(n, m, baseNameStart * scorePattern(n, n, sameCase, start, end), pos);
 }
 
 

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -435,7 +435,7 @@ Score scoreExactMatch(const CandidateString &subject, const CandidateString &sub
 
 AcronymResult emptyAcronymResult(static_cast<Score>(0), static_cast<float>(0.1), static_cast<int>(0));
 
-AcronymResult scoreAcronyms(const CandidateString subject, const CandidateString subject_lw, const Element query, const Element query_lw) {
+AcronymResult scoreAcronyms(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw) {
     const auto m = subject.size();
     const auto n = query.size();
 

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -158,8 +158,9 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
     csc_row[j] = 0;
   }*/
 
-    auto i = -1;
-    while (++i < m) {//foreach char si of subject
+    auto i = 0u;
+    while (i < m) {//foreach char si of subject
+        //assert(i >= 0);// fuzz: if m==0, does not enter while and i==0
         auto si_lw = subject_lw[i];
 
         // if si_lw is not in query
@@ -167,12 +168,16 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
             // reset csc_row and move to next subject char
             // unless we just cleaned it then keep cleaned version.
             if (csc_should_rebuild) {
-                auto j = -1;
-                while (++j < n) {
-                    csc_row[j] = 0;
+                auto k = 0u;
+                while (k < n) {
+                    //assert(k >= 0);// fuzz: if n==0, does not enter while and k==0
+                    csc_row[k] = 0;
+                    ++k;
                 }
                 csc_should_rebuild = false;
             }
+
+            ++i;
             continue;
         }
 
@@ -182,9 +187,9 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
         auto record_miss = true;
         csc_should_rebuild = true;
 
-        auto j = -1;//0..n-1
-        while (++j < n) {//foreach char qj of query
-
+        auto j = 0u;//0..n-1
+        while (j < n) {//foreach char qj of query
+            //assert(j >= 0);// fuzz: if n==0, does not enter while and j==0
             // What is the best gap ?
             // score_up contain the score of a gap in subject.
             // score_left = last iteration of score, -> gap in query.
@@ -230,7 +235,11 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
             csc_diag = csc_row[j];
             csc_row[j] = csc_score;
             score_row[j] = score;
+
+            ++j;
         }
+
+        ++i;
     }
 
     // get highest score so far
@@ -350,7 +359,7 @@ Score scoreCharacter(const int i, const int j, const bool start, const Score acr
 //
 // Forward search for a sequence of consecutive character.
 //
-Score scoreConsecutives(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int i, int j, const bool startOfWord) {
+Score scoreConsecutives(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, unsigned i, unsigned j, const bool startOfWord) {
     const auto m = subject.size();
     const auto n = query.size();
 

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -34,8 +34,8 @@ extern bool isWordEnd(const int pos, const CandidateString &subject, const Candi
 extern bool isSeparator(const char c);
 extern Score scoreExact(const size_t n, const size_t m, const size_t quality, const Score pos);
 
-extern Score scorePattern(const size_t count, const size_t len, const int sameCase, const bool start, const bool end) noexcept;
-extern Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, const size_t n, const size_t m);
+extern Score scorePattern(const size_t count, const size_t len, const size_t sameCase, const bool start, const bool end) noexcept;
+extern Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, size_t pos, const size_t n, const size_t m);
 
 extern bool isAcronymFullWord(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const unsigned nbAcronymInQuery);
 
@@ -305,7 +305,7 @@ Score scoreExact(const size_t n, const size_t m, const size_t quality, const Sco
 // and structural quality of the pattern on the overall string (word boundary)
 //
 
-Score scorePattern(const size_t count, const size_t len, const int sameCase, const bool start, const bool end) noexcept {
+Score scorePattern(const size_t count, const size_t len, const size_t sameCase, const bool start, const bool end) noexcept {
     auto sz = count;
 
     auto bonus = 6;// to ensure consecutive length dominate score, this should be as large other bonus combined
@@ -367,7 +367,7 @@ Score scoreConsecutives(const CandidateString &subject, const CandidateString &s
     const int nj = n - j;
     const auto k = mi < nj ? mi : nj;
 
-    auto sameCase = 0;
+    auto sameCase = 0u;
     auto sz = 0u;//sz will be one more than the last qi is sj
 
     // query_lw[i] is subject_lw[j] has been checked before entering now do case sensitive check.
@@ -404,7 +404,7 @@ Score scoreConsecutives(const CandidateString &subject, const CandidateString &s
 //
 // Compute the score of an exact match at position pos.
 //
-Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, const size_t n, const size_t m) {
+Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, size_t pos, const size_t n, const size_t m) {
 
     // Test for word start
     auto start = isWordStart(pos, subject, subject_lw);
@@ -427,7 +427,7 @@ Score scoreExactMatch(const CandidateString &subject, const CandidateString &sub
 
     //Exact case bonus.
     auto i = -1;
-    auto sameCase = 0;
+    auto sameCase = 0u;
     while (++i < n) {
         if (query[i] == subject[pos + i]) {
             sameCase++;

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -354,8 +354,8 @@ Score scoreConsecutives(const CandidateString &subject, const CandidateString &s
     const auto m = subject.size();
     const auto n = query.size();
 
-    int mi = m - i;
-    int nj = n - j;
+    const int mi = m - i;
+    const int nj = n - j;
     const auto k = mi < nj ? mi : nj;
 
     auto sameCase = 0;

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -35,7 +35,7 @@ extern bool isSeparator(const char c);
 extern Score scoreExact(const size_t n, const size_t m, const size_t quality, const Score pos);
 
 extern Score scorePattern(const int count, const int len, const int sameCase, const bool start, const bool end) noexcept;
-extern Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, const int n, const int m);
+extern Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, const size_t n, const int m);
 
 extern bool isAcronymFullWord(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const unsigned nbAcronymInQuery);
 
@@ -359,7 +359,7 @@ Score scoreConsecutives(const CandidateString &subject, const CandidateString &s
     const auto k = mi < nj ? mi : nj;
 
     auto sameCase = 0;
-    auto sz = 0;//sz will be one more than the last qi is sj
+    auto sz = 0u;//sz will be one more than the last qi is sj
 
     // query_lw[i] is subject_lw[j] has been checked before entering now do case sensitive check.
     if (query[j] == subject[i]) {
@@ -395,7 +395,7 @@ Score scoreConsecutives(const CandidateString &subject, const CandidateString &s
 //
 // Compute the score of an exact match at position pos.
 //
-Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, const int n, const int m) {
+Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, const size_t n, const int m) {
 
     // Test for word start
     auto start = isWordStart(pos, subject, subject_lw);

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -245,7 +245,7 @@ bool isWordStart(const int pos, const CandidateString &subject, const CandidateS
     const auto curr_s = subject[pos];
     const auto prev_s = subject[pos - 1];
     return isSeparator(prev_s) ||// match FOLLOW a separator
-           curr_s != subject_lw[pos] && prev_s == subject_lw[pos - 1];// match is Capital in camelCase (preceded by lowercase)
+           ((curr_s != subject_lw[pos]) && (prev_s == subject_lw[pos - 1]));// match is Capital in camelCase (preceded by lowercase)
 }
 
 bool isWordEnd(const int pos, const CandidateString &subject, const CandidateString &subject_lw, const int len) {
@@ -255,7 +255,7 @@ bool isWordEnd(const int pos, const CandidateString &subject, const CandidateStr
     const auto curr_s = subject[pos];
     const auto next_s = subject[pos + 1];
     return isSeparator(next_s) ||// match IS FOLLOWED BY a separator
-           curr_s == subject_lw[pos] && next_s != subject_lw[pos + 1];// match is lowercase, followed by uppercase
+           ((curr_s == subject_lw[pos]) && (next_s != subject_lw[pos + 1]));// match is lowercase, followed by uppercase
 }
 
 bool isSeparator(const char c) {

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -34,7 +34,7 @@ extern bool isWordEnd(const int pos, const CandidateString &subject, const Candi
 extern bool isSeparator(const char c);
 extern Score scoreExact(const size_t n, const size_t m, const size_t quality, const Score pos);
 
-extern Score scorePattern(const int count, const int len, const int sameCase, const bool start, const bool end) noexcept;
+extern Score scorePattern(const size_t count, const size_t len, const int sameCase, const bool start, const bool end) noexcept;
 extern Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, const size_t n, const size_t m);
 
 extern bool isAcronymFullWord(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const unsigned nbAcronymInQuery);
@@ -296,7 +296,7 @@ Score scoreExact(const size_t n, const size_t m, const size_t quality, const Sco
 // and structural quality of the pattern on the overall string (word boundary)
 //
 
-Score scorePattern(const int count, const int len, const int sameCase, const bool start, const bool end) noexcept {
+Score scorePattern(const size_t count, const size_t len, const int sameCase, const bool start, const bool end) noexcept {
     auto sz = count;
 
     auto bonus = 6;// to ensure consecutive length dominate score, this should be as large other bonus combined

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -30,14 +30,14 @@ const float miss_coeff = 0.75;// Max number missed consecutive hit = ceil(miss_c
 
 }// namespace
 
-extern bool isWordEnd(int pos, const CandidateString &subject, const CandidateString &subject_lw, int len);
-extern bool isSeparator(char c);
-extern Score scoreExact(size_t n, size_t m, size_t quality, Score pos);
+extern bool isWordEnd(const int pos, const CandidateString &subject, const CandidateString &subject_lw, const int len);
+extern bool isSeparator(const char c);
+extern Score scoreExact(const size_t n, const size_t m, const size_t quality, const Score pos);
 
 extern Score scorePattern(int count, int len, bool sameCase, bool start, bool end);
-extern Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, int n, int m);
+extern Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, const int n, const int m);
 
-extern bool isAcronymFullWord(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, int nbAcronymInQuery);
+extern bool isAcronymFullWord(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const int nbAcronymInQuery);
 
 
 //
@@ -61,8 +61,8 @@ Score scorer_score(const CandidateString &string, const Element &query, const Op
 // Are all (non optional)characters of query in subject, in proper order ?
 //
 bool isMatch(const CandidateString &subject, const Element &query_lw, const Element &query_up) {
-    const int m = subject.size();
-    const int n = query_lw.size();
+    const auto m = subject.size();
+    const auto n = query_lw.size();
 
     if (m == 0 || n > m) {
         return false;
@@ -104,8 +104,8 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
     const auto &query = preparedQuery.query;
     const auto &query_lw = preparedQuery.query_lw;
 
-    const int m = subject.size();
-    const int n = query.size();
+    const auto m = subject.size();
+    const auto n = query.size();
 
     //----------------------------
     // Abbreviations sequence
@@ -238,7 +238,7 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
 // Is the character at the start of a word, end of the word, or a separator ?
 // Fortunately those small function inline well.
 //
-bool isWordStart(int pos, const CandidateString &subject, const CandidateString &subject_lw) {
+bool isWordStart(const int pos, const CandidateString &subject, const CandidateString &subject_lw) {
     if (pos == 0) {
         return true;// match is FIRST char ( place a virtual token separator before first char of string)
     }
@@ -248,7 +248,7 @@ bool isWordStart(int pos, const CandidateString &subject, const CandidateString 
            curr_s != subject_lw[pos] && prev_s == subject_lw[pos - 1];// match is Capital in camelCase (preceded by lowercase)
 }
 
-bool isWordEnd(int pos, const CandidateString &subject, const CandidateString &subject_lw, int len) {
+bool isWordEnd(const int pos, const CandidateString &subject, const CandidateString &subject_lw, const int len) {
     if (pos == len - 1) {
         return true;// last char of string
     }
@@ -258,14 +258,14 @@ bool isWordEnd(int pos, const CandidateString &subject, const CandidateString &s
            curr_s == subject_lw[pos] && next_s != subject_lw[pos + 1];// match is lowercase, followed by uppercase
 }
 
-bool isSeparator(char c) {
+bool isSeparator(const char c) {
     return c == ' ' || c == '.' || c == '-' || c == '_' || c == '/' || c == '\\';
 }
 
 //
 // Scoring helper
 //
-Score scorePosition(Score pos) {
+Score scorePosition(const Score pos) {
     if (pos < pos_bonus) {
         const auto sc = pos_bonus - pos;
         return 100 + sc * sc;
@@ -273,12 +273,12 @@ Score scorePosition(Score pos) {
     return fmax(100 + pos_bonus - pos, 0);
 }
 
-Score scoreSize(Score n, Score m) {
+Score scoreSize(const Score n, const Score m) {
     // Size penalty, use the difference of size (m-n)
     return tau_size / (tau_size + fabs(m - n));
 }
 
-Score scoreExact(size_t n, size_t m, size_t quality, Score pos) {
+Score scoreExact(const size_t n, const size_t m, const size_t quality, const Score pos) {
     return 2 * n * (wm * quality + scorePosition(pos)) * scoreSize(n, m);
 }
 
@@ -289,7 +289,7 @@ Score scoreExact(size_t n, size_t m, size_t quality, Score pos) {
 // and structural quality of the pattern on the overall string (word boundary)
 //
 
-Score scorePattern(int count, int len, int sameCase, bool start, bool end) {
+Score scorePattern(const int count, const int len, const int sameCase, const bool start, const bool end) {
     auto sz = count;
 
     auto bonus = 6;// to ensure consecutive length dominate score, this should be as large other bonus combined
@@ -324,7 +324,7 @@ Score scorePattern(int count, int len, int sameCase, bool start, bool end) {
 //
 // Compute the bonuses for two chars that are confirmed to matches in a case-insensitive way
 //
-Score scoreCharacter(int i, int j, bool start, Score acro_score, Score csc_score) {
+Score scoreCharacter(const int i, const int j, const bool start, const Score acro_score, const Score csc_score) {
 
     // start of string / position of match bonus
     const auto posBonus = scorePosition(i);
@@ -343,7 +343,7 @@ Score scoreCharacter(int i, int j, bool start, Score acro_score, Score csc_score
 //
 // Forward search for a sequence of consecutive character.
 //
-Score scoreConsecutives(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int i, int j, bool startOfWord) {
+Score scoreConsecutives(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int i, int j, const bool startOfWord) {
     const auto m = subject.size();
     const auto n = query.size();
 
@@ -388,7 +388,7 @@ Score scoreConsecutives(const CandidateString &subject, const CandidateString &s
 //
 // Compute the score of an exact match at position pos.
 //
-Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, int n, int m) {
+Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, const int n, const int m) {
 
     // Test for word start
     auto start = isWordStart(pos, subject, subject_lw);
@@ -435,7 +435,7 @@ Score scoreExactMatch(const CandidateString &subject, const CandidateString &sub
 
 AcronymResult emptyAcronymResult(static_cast<Score>(0), static_cast<float>(0.1), static_cast<int>(0));
 
-AcronymResult scoreAcronyms(CandidateString subject, CandidateString subject_lw, Element query, Element query_lw) {
+AcronymResult scoreAcronyms(const CandidateString subject, const CandidateString subject_lw, const Element query, const Element query_lw) {
     const auto m = subject.size();
     const auto n = query.size();
 
@@ -512,7 +512,7 @@ AcronymResult scoreAcronyms(CandidateString subject, CandidateString subject_lw,
 //
 // This method check for (b) assuming (a) has been checked before entering.
 
-bool isAcronymFullWord(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, int nbAcronymInQuery) {
+bool isAcronymFullWord(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const int nbAcronymInQuery) {
     const int m = subject.size();
     const int n = query.size();
     auto count = 0;

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -451,7 +451,7 @@ AcronymResult scoreAcronyms(const CandidateString &subject, const CandidateStrin
         return emptyAcronymResult;
     }
 
-    size_t count = 0;
+    auto count = 0u;
     auto sepCount = 0;
     auto sumPos = 0;
     auto sameCase = 0;
@@ -459,8 +459,8 @@ AcronymResult scoreAcronyms(const CandidateString &subject, const CandidateStrin
     auto i = string::npos;// incrementing will become 0
 
     //foreach char of query
-    for (size_t j = 0; j < n; j++) {
-        const auto qj_lw = query_lw[j];
+    for (auto j = 0u; j < n; j++) {
+        const auto qj_lw = query_lw[j];// TODO bounds
 
         // Separator will not score point but will continue the prefix when present.
         // Test that the separator is in the candidate and advance cursor to that position.
@@ -480,7 +480,7 @@ AcronymResult scoreAcronyms(const CandidateString &subject, const CandidateStrin
 
         while (++i < m) {
             if (qj_lw == subject_lw[i] && isWordStart(i, subject, subject_lw)) {
-                if (query[j] == subject[i]) {
+                if (query[j] == subject[i]) {// TODO bounds
                     sameCase++;
                 }
                 sumPos += i;

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -68,27 +68,34 @@ bool isMatch(const CandidateString &subject, const Element &query_lw, const Elem
         return false;
     }
 
-    auto i = -1;
-    auto j = -1;
+    auto i = 0u;
+    auto j = 0u;
 
     // foreach char of query
-    while (++j < n) {
-        const auto qj_lw = query_lw[j];
-        const auto qj_up = query_up[j];
+    while (j < n) {
+        // assert(j >= 0); // fuzz: if n==0, j becomes 0
+        const auto qj_lw = query_lw[j];// inbounds
+        const auto qj_up = query_up[j];// TODO bounds
 
         // continue walking the subject from where we have left with previous query char
         // until we have found a character that is either lowercase or uppercase query.
-        while (++i < m) {
-            const auto si = subject[i];
+        while (i < m) {
+            // assert(j >= 0); // fuzz: if m==0, i becomes 0
+            const auto si = subject[i];// inbounds
             if (si == qj_lw || si == qj_up) {
                 break;
             }
+
+            ++i;
         }
 
         // if we passed the last char, query is not in subject
         if (i == m) {
+            //assert(i >= 0); // fuzz: if m==0, i is 0
             return false;
         }
+
+        ++j;
     }
 
     // Found every char of query in subject in proper order, match is positive

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -440,7 +440,7 @@ Score scoreExactMatch(const CandidateString &subject, const CandidateString &sub
 // Acronym prefix
 //
 
-AcronymResult emptyAcronymResult(static_cast<Score>(0), static_cast<float>(0.1), static_cast<int>(0));
+const auto emptyAcronymResult = AcronymResult(static_cast<Score>(0), static_cast<float>(0.1), static_cast<int>(0));
 
 AcronymResult scoreAcronyms(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw) {
     const auto m = subject.size();

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -363,8 +363,8 @@ Score scoreConsecutives(const CandidateString &subject, const CandidateString &s
     const auto m = subject.size();
     const auto n = query.size();
 
-    const int mi = m - i;
-    const int nj = n - j;
+    const auto mi = m - i;
+    const auto nj = n - j;
     const auto k = mi < nj ? mi : nj;
 
     auto sameCase = 0u;

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -209,8 +209,9 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
                     // If budget is exhausted exit
                     // Each character of query have it's score history stored in score_row
                     // To get full query score use last item of row.
-                    if (record_miss && --miss_left <= 0)
+                    if (record_miss && --miss_left <= 0) {
                         return fmax(score, score_row[n - 1]) * sz;
+                    }
 
                     record_miss = false;
                 }
@@ -225,7 +226,7 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
         }
     }
 
-    // get hightest score so far
+    // get highest score so far
     const auto score = score_row[n - 1];
     return score * sz;
 }

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -426,12 +426,14 @@ Score scoreExactMatch(const CandidateString &subject, const CandidateString &sub
     }
 
     //Exact case bonus.
-    auto i = -1;
+    auto i = 0u;
     auto sameCase = 0u;
-    while (++i < n) {
+    while (i < n) {
+        // assert(i>=0); // fuzz: if n==0, does not enter while and i==0u
         if (query[i] == subject[pos + i]) {
             sameCase++;
         }
+        ++i;
     }
 
     const auto end = static_cast<int>(isWordEnd(pos + n - 1, subject, subject_lw, m));

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -11,13 +11,13 @@ namespace {
 
 // Base point for a single character match
 // This balance making patterns VS position and size penalty.
-const int wm = 150;
+constexpr int wm = 150;
 
 // Fading function
 // The character from 0..pos_bonus receive a greater bonus for being at the start of string.
-const Score pos_bonus = 20;
+constexpr Score pos_bonus = 20;
 // Full path length at which the whole match score is halved.
-const Score tau_size = 150;
+constexpr Score tau_size = 150;
 
 // Miss count
 // When subject[i] is query[j] we register a hit.
@@ -26,7 +26,7 @@ const Score tau_size = 150;
 //
 // If a spec with frequent repetition fail, increase this.
 // This has a direct influence on worst case scenario benchmark.
-const float miss_coeff = 0.75;// Max number missed consecutive hit = ceil(miss_coeff*query.length) + 5
+constexpr float miss_coeff = 0.75;// Max number missed consecutive hit = ceil(miss_coeff*query.length) + 5
 
 }// namespace
 

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -30,7 +30,7 @@ constexpr float miss_coeff = 0.75;// Max number missed consecutive hit = ceil(mi
 
 }// namespace
 
-extern bool isWordEnd(const int pos, const CandidateString &subject, const CandidateString &subject_lw, const int len);
+extern bool isWordEnd(const size_t pos, const CandidateString &subject, const CandidateString &subject_lw, const size_t len);
 extern bool isSeparator(const char c);
 extern Score scoreExact(const size_t n, const size_t m, const size_t quality, const Score pos);
 
@@ -264,8 +264,8 @@ bool isWordStart(const size_t pos, const CandidateString &subject, const Candida
            ((curr_s != subject_lw[pos]) && (prev_s == subject_lw[pos - 1]));// match is Capital in camelCase (preceded by lowercase)
 }
 
-bool isWordEnd(const int pos, const CandidateString &subject, const CandidateString &subject_lw, const int len) {
-    if (pos == len - 1) {
+bool isWordEnd(const size_t pos, const CandidateString &subject, const CandidateString &subject_lw, const size_t len) {
+    if (pos == len - 1u) {
         return true;// last char of string
     }
     const auto curr_s = subject[pos];
@@ -436,7 +436,7 @@ Score scoreExactMatch(const CandidateString &subject, const CandidateString &sub
         ++i;
     }
 
-    const auto end = static_cast<int>(isWordEnd(pos + n - 1, subject, subject_lw, m));
+    const auto end = static_cast<int>(isWordEnd(pos + n - 1u, subject, subject_lw, m));
 
     Score baseNameStart = 1.0;
     if (start && pos > 0 && (subject[pos - 1] == '/' || subject[pos - 1] == '\\')) {

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -34,7 +34,7 @@ extern bool isWordEnd(const int pos, const CandidateString &subject, const Candi
 extern bool isSeparator(const char c);
 extern Score scoreExact(const size_t n, const size_t m, const size_t quality, const Score pos);
 
-extern Score scorePattern(int count, int len, bool sameCase, bool start, bool end);
+extern Score scorePattern(const int count, const int len, const int sameCase, const bool start, const bool end) noexcept;
 extern Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, const int n, const int m);
 
 extern bool isAcronymFullWord(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const int nbAcronymInQuery);
@@ -296,7 +296,7 @@ Score scoreExact(const size_t n, const size_t m, const size_t quality, const Sco
 // and structural quality of the pattern on the overall string (word boundary)
 //
 
-Score scorePattern(const int count, const int len, const int sameCase, const bool start, const bool end) {
+Score scorePattern(const int count, const int len, const int sameCase, const bool start, const bool end) noexcept {
     auto sz = count;
 
     auto bonus = 6;// to ensure consecutive length dominate score, this should be as large other bonus combined

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -254,7 +254,7 @@ Score computeScore(const CandidateString &subject, const CandidateString &subjec
 // Is the character at the start of a word, end of the word, or a separator ?
 // Fortunately those small function inline well.
 //
-bool isWordStart(const int pos, const CandidateString &subject, const CandidateString &subject_lw) {
+bool isWordStart(const size_t pos, const CandidateString &subject, const CandidateString &subject_lw) {
     if (pos == 0) {
         return true;// match is FIRST char ( place a virtual token separator before first char of string)
     }

--- a/src/scorer.cc
+++ b/src/scorer.cc
@@ -35,7 +35,7 @@ extern bool isSeparator(const char c);
 extern Score scoreExact(const size_t n, const size_t m, const size_t quality, const Score pos);
 
 extern Score scorePattern(const int count, const int len, const int sameCase, const bool start, const bool end) noexcept;
-extern Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, const size_t n, const int m);
+extern Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, const size_t n, const size_t m);
 
 extern bool isAcronymFullWord(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const unsigned nbAcronymInQuery);
 
@@ -395,7 +395,7 @@ Score scoreConsecutives(const CandidateString &subject, const CandidateString &s
 //
 // Compute the score of an exact match at position pos.
 //
-Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, const size_t n, const int m) {
+Score scoreExactMatch(const CandidateString &subject, const CandidateString &subject_lw, const Element &query, const Element &query_lw, int pos, const size_t n, const size_t m) {
 
     // Test for word start
     auto start = isWordStart(pos, subject, subject_lw);

--- a/src/tree.h
+++ b/src/tree.h
@@ -34,13 +34,11 @@ struct CandidateObject {
 
 template<typename T>
 struct Tree {
-    T jsTreeArrayOrObject;
-    string dataKey;
-    string childrenKey;
-
-
+    const string &dataKey;
+    const string &childrenKey;
     /** an array of the CandidateObject which includes the data and its address (index, level) in the tree for each */
     vector<CandidateObject> entriesArray;
+
 
     /** Recursive function that fills the entriesArray from the given jsTreeArray */
     void makeEntriesArray(const Napi::Array &jsTreeArray, const size_t level) {
@@ -65,10 +63,9 @@ struct Tree {
     }
 
     /** create a Tree object and make an entries array */
-    Tree(T const _jsTreeArrayOrObject, string const _dataKey, string const _childrenKey) {
-        dataKey = _dataKey;
-        childrenKey = _childrenKey;
-        jsTreeArrayOrObject = _jsTreeArrayOrObject;
-        makeEntriesArray(jsTreeArrayOrObject, 0);
+    Tree(const T &jsTreeArrayOrObject_, const string &dataKey_, const string &childrenKey_)
+      : dataKey{ dataKey_ },
+        childrenKey{ childrenKey_ } {
+        makeEntriesArray(jsTreeArrayOrObject_, 0);
     }
 };

--- a/src/tree.h
+++ b/src/tree.h
@@ -4,7 +4,7 @@
 #include "common.h"
 
 /** Get the children of a jsTree (Napi::Object) */
-std::optional<Napi::Array> getChildren(Napi::Object const &jsTree, string const &childrenKey) {
+std::optional<Napi::Array> getChildren(const Napi::Object &jsTree, const string &childrenKey) {
     Napi::Array childrenArray;
 
     // determine if it has children
@@ -44,7 +44,7 @@ struct Tree {
     vector<CandidateObject> entriesArray;
 
     /** Recursive function that fills the entriesArray from the given jsTreeArray */
-    void makeEntriesArray(Napi::Array const &jsTreeArray, size_t const level) {
+    void makeEntriesArray(const Napi::Array &jsTreeArray, const size_t level) {
         for (uint32_t iEntry = 0, len = jsTreeArray.Length(); iEntry < len; iEntry++) {
             auto jsTree = jsTreeArray[iEntry].As<Napi::Object>();
             makeEntriesArray(jsTree, level, iEntry);
@@ -52,7 +52,7 @@ struct Tree {
     }
 
     /** 1st argument is a single object */
-    void makeEntriesArray(Napi::Object const &jsTree, size_t const level, int32_t const iEntry = -1) {
+    void makeEntriesArray(const Napi::Object &jsTree, const size_t level, const int32_t iEntry = -1) {
         // get the current data
         const auto data = jsTree.Get(dataKey).ToString().Utf8Value();
         entriesArray.push_back(CandidateObject(data, level, iEntry));

--- a/src/tree.h
+++ b/src/tree.h
@@ -52,7 +52,7 @@ struct Tree {
     void makeEntriesArray(const Napi::Object &jsTree, const size_t level, const int32_t iEntry = -1) {
         // get the current data
         const auto &data = jsTree.Get(dataKey).ToString().Utf8Value();
-        entriesArray.push_back(CandidateObject(data, level, iEntry));
+        entriesArray.emplace_back(CandidateObject(data, level, iEntry));
 
         // add children if any
         auto mayChildren = getChildren(jsTree, childrenKey);

--- a/src/tree.h
+++ b/src/tree.h
@@ -24,12 +24,12 @@ std::optional<Napi::Array> getChildren(const Napi::Object &jsTree, const string 
 
 
 struct CandidateObject {
-    CandidateString data;
+    const CandidateString data;
     const size_t level = 0;
-    const int32_t index = -1;
+    const size_t index = 0;
 
-    CandidateObject(CandidateString const data, size_t const level, int32_t const index)
-      : data{ data }, level{ level }, index{ index } {};
+    CandidateObject(const CandidateString data_, const size_t level_, const size_t index_) noexcept
+      : data{ data_ }, level{ level_ }, index{ index_ } {};
 };
 
 template<typename T>
@@ -49,7 +49,7 @@ struct Tree {
     }
 
     /** 1st argument is a single object */
-    void makeEntriesArray(const Napi::Object &jsTree, const size_t level, const int32_t iEntry = -1) {
+    void makeEntriesArray(const Napi::Object &jsTree, const size_t level, const size_t iEntry = -1) {
         // get the current data
         const auto &data = jsTree.Get(dataKey).ToString().Utf8Value();
         entriesArray.emplace_back(CandidateObject(data, level, iEntry));

--- a/src/tree.h
+++ b/src/tree.h
@@ -53,7 +53,7 @@ struct Tree {
     /** 1st argument is a single object */
     void makeEntriesArray(const Napi::Object &jsTree, const size_t level, const int32_t iEntry = -1) {
         // get the current data
-        const auto data = jsTree.Get(dataKey).ToString().Utf8Value();
+        const auto &data = jsTree.Get(dataKey).ToString().Utf8Value();
         entriesArray.push_back(CandidateObject(data, level, iEntry));
 
         // add children if any

--- a/src/tree.h
+++ b/src/tree.h
@@ -17,14 +17,15 @@ std::optional<Napi::Array> getChildren(const Napi::Object &jsTree, const string 
             }
         }
     }
-    if (hasChildren)
+    if (hasChildren) {
         return childrenArray;
+    }
     return {};
 }
 
 
 struct CandidateObject {
-    const CandidateString data;
+    const CandidateString data;// TODO copy
     const size_t level = 0;
     const size_t index = 0;
 

--- a/src/tree.h
+++ b/src/tree.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <optional>
-#include <variant>
 #include "common.h"
 
 /** Get the children of a jsTree (Napi::Object) */

--- a/src/tree.h
+++ b/src/tree.h
@@ -44,7 +44,7 @@ struct Tree {
 
     /** Recursive function that fills the entriesArray from the given jsTreeArray */
     void makeEntriesArray(const Napi::Array &jsTreeArray, const size_t level) {
-        for (uint32_t iEntry = 0, len = jsTreeArray.Length(); iEntry < len; iEntry++) {
+        for (auto iEntry = 0u, len = jsTreeArray.Length(); iEntry < len; iEntry++) {
             auto jsTree = jsTreeArray[iEntry].As<Napi::Object>();
             makeEntriesArray(jsTree, level, iEntry);
         }

--- a/src/tree.h
+++ b/src/tree.h
@@ -25,8 +25,8 @@ std::optional<Napi::Array> getChildren(const Napi::Object &jsTree, const string 
 
 struct CandidateObject {
     CandidateString data;
-    size_t level = 0;
-    int32_t index = -1;
+    const size_t level = 0;
+    const int32_t index = -1;
 
     CandidateObject(CandidateString const data, size_t const level, int32_t const index)
       : data{ data }, level{ level }, index{ index } {};

--- a/src/tree.h
+++ b/src/tree.h
@@ -4,7 +4,7 @@
 #include "common.h"
 
 /** Get the children of a jsTree (Napi::Object) */
-const std::optional<Napi::Array> getChildren(Napi::Object const &jsTree, string const &childrenKey) {
+std::optional<Napi::Array> getChildren(Napi::Object const &jsTree, string const &childrenKey) {
     Napi::Array childrenArray;
 
     // determine if it has children


### PR DESCRIPTION
- Improved Tree struct by not storing the jsTreeObjecrOrArray

This is a continuation of #35 by applying more fixes (mostly manual):
- Avoid copying by using references
- Adds const where possible
- Adds `{}` and `()` to prevent errors
- Add noexcept to some classes
- Use emplace_back instead of push_back
- Adding some TODOs for fixing copying
etc


<details>
<summary>Benchmarks</summary>

TwoLetter#Filter seems faster now.

Benchmarks after:

```
> npm run benchmark:small && npm run benchmark:regular && npm run benchmark:large


> fuzzaldrin-plus-fast@1.1.0 benchmark:small
> node benchmark/benchmark-small.js

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 1 ms
length 100 100

====== Running test - query:npm ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 4 ms
length 55 100

====== Running test - query:node ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 1 ms
length 100 100

====== Running test - query:grunt ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 1 ms
length 33 100

====== Running test - query:html ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 0 ms
length 10 100

====== Running test - query:doc ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 5 ms
length 87 100

====== Running test - query:cli ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 2 ms
length 57 100

====== Running test - query:js ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 0 ms
length 60 100

====== Running test - query:jas ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 0 ms
length 19 100

====== Running test - query:mine ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 3 ms
length 65 100

====== Running test - query:stream ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 1 ms
length 19 100


> fuzzaldrin-plus-fast@1.1.0 benchmark:regular
> node benchmark/benchmark.js

====== Running test - query:index ======
Elapsed time - fuzzaldrin-plus-fast: 29 ms vs. fuzzaldrin-plus: 44 ms
length 6168 66672

====== Running test - query:indx ======
Elapsed time - fuzzaldrin-plus-fast: 29 ms vs. fuzzaldrin-plus: 51 ms
length 6192 66672

====== Running test - query:walkdr ======
Elapsed time - fuzzaldrin-plus-fast: 25 ms vs. fuzzaldrin-plus: 16 ms
length 504 66672
====== fuzzaldrin-plus-fast is SLOWER

====== Running test - query:node ======
Elapsed time - fuzzaldrin-plus-fast: 47 ms vs. fuzzaldrin-plus: 69 ms
length 65136 66672

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 45 ms vs. fuzzaldrin-plus: 65 ms
length 65208 66672

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 46 ms vs. fuzzaldrin-plus: 54 ms
length 65208 66672

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 46 ms vs. fuzzaldrin-plus: 59 ms
length 65208 66672

====== Running test - query:ndem ======
Elapsed time - fuzzaldrin-plus-fast: 53 ms vs. fuzzaldrin-plus: 236 ms
length 65124 66672

Matching 66672 results for 'index' took 283ms (Prepare in advance)
Matching 66672 results for 'index' took 280ms (cache)
Matching 66672 results for 'index' took 90ms (legacy)

> fuzzaldrin-plus-fast@1.1.0 benchmark:large
> node benchmark/benchmark-large.js

TwoLetter#legacy: 10.746s
TwoLetter#fuzzaldrin-plus-fast#DirectFilter: 3.209s
TwoLetter#fuzzaldrin-plus-fast#setCandidates#filter: 429.91ms
======
ThreeLetter#legacy: 8.825s
ThreeLetter#fuzzaldrin-plus-fast#DirectFilter: 3.384s
ThreeLetter#fuzzaldrin-plus-fast#setCandidates#filter: 449.717ms
======
TwoLetter#Keybased#Filter: 3.914s
ThreeLetter#Keybased#Filter: 4.579s
======
setCandidates: 224.735ms
TwoLetter#Filter: 422.389ms
ThreeLetter#Filter: 497.014ms
======
setCandidates#Keybased: 229.815ms
TwoLetter#Keybased#Filter: 421.57ms
ThreeLetter#Keybased#Filter: 438.628ms
```

Benchmarks on the previosu released version:

```
> npm run benchmark:small && npm run benchmark:regular && npm run benchmark:large


> fuzzaldrin-plus-fast@1.1.0 benchmark:small
> node benchmark/benchmark-small.js

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 0 ms
length 100 100

====== Running test - query:npm ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 4 ms
length 55 100

====== Running test - query:node ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 1 ms
length 100 100

====== Running test - query:grunt ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 0 ms
length 33 100

====== Running test - query:html ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 0 ms
length 10 100

====== Running test - query:doc ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 4 ms
length 87 100

====== Running test - query:cli ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 2 ms
length 57 100

====== Running test - query:js ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 0 ms
length 60 100

====== Running test - query:jas ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 0 ms
length 19 100

====== Running test - query:mine ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 2 ms
length 65 100

====== Running test - query:stream ======
Elapsed time - fuzzaldrin-plus-fast: 0 ms vs. fuzzaldrin-plus: 2 ms
length 19 100


> fuzzaldrin-plus-fast@1.1.0 benchmark:regular
> node benchmark/benchmark.js

====== Running test - query:index ======
Elapsed time - fuzzaldrin-plus-fast: 29 ms vs. fuzzaldrin-plus: 44 ms
length 6168 66672

====== Running test - query:indx ======
Elapsed time - fuzzaldrin-plus-fast: 30 ms vs. fuzzaldrin-plus: 52 ms
length 6192 66672

====== Running test - query:walkdr ======
Elapsed time - fuzzaldrin-plus-fast: 27 ms vs. fuzzaldrin-plus: 16 ms
length 504 66672
====== fuzzaldrin-plus-fast is SLOWER

====== Running test - query:node ======
Elapsed time - fuzzaldrin-plus-fast: 51 ms vs. fuzzaldrin-plus: 68 ms
length 65136 66672

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 51 ms vs. fuzzaldrin-plus: 68 ms
length 65208 66672

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 50 ms vs. fuzzaldrin-plus: 51 ms
length 65208 66672

====== Running test - query:nm ======
Elapsed time - fuzzaldrin-plus-fast: 51 ms vs. fuzzaldrin-plus: 58 ms
length 65208 66672

====== Running test - query:ndem ======
Elapsed time - fuzzaldrin-plus-fast: 51 ms vs. fuzzaldrin-plus: 234 ms
length 65124 66672

Matching 66672 results for 'index' took 289ms (Prepare in advance)
Matching 66672 results for 'index' took 286ms (cache)
Matching 66672 results for 'index' took 84ms (legacy)

> fuzzaldrin-plus-fast@1.1.0 benchmark:large
> node benchmark/benchmark-large.js

TwoLetter#legacy: 10.584s
TwoLetter#fuzzaldrin-plus-fast#DirectFilter: 3.244s
TwoLetter#fuzzaldrin-plus-fast#setCandidates#filter: 483.943ms
======
ThreeLetter#legacy: 8.889s
ThreeLetter#fuzzaldrin-plus-fast#DirectFilter: 3.368s
ThreeLetter#fuzzaldrin-plus-fast#setCandidates#filter: 431.151ms
======
TwoLetter#Keybased#Filter: 3.992s
ThreeLetter#Keybased#Filter: 4.630s
======
setCandidates: 223.59ms
TwoLetter#Filter: 636.285ms
ThreeLetter#Filter: 434.577ms
======
setCandidates#Keybased: 234.892ms
TwoLetter#Keybased#Filter: 498.664ms
ThreeLetter#Keybased#Filter: 444.204ms
```

</details>