### PR TITLE
major: Rename the library to Zadeh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-![CI](https://github.com/atom-ide-community/fuzzaldrin-plus-fast/workflows/CI/badge.svg)
+![CI](https://github.com/atom-ide-community/zadeh/workflows/CI/badge.svg)
 
-Fast fuzzy-search - the native replacement for `fuzzaldrin-plus`
+Blazing fast library for fuzzy filtering, matching, and other fuzzy things!
 
-# What is fuzzaldrin-plus-fast?
+# What is Zadeh?
 
 - Fuzzaldrin plus is an awesome library that provides fuzzy-search that is more targeted towards filenames.
-- Fuzzaldrin-plus-fast is a rewrite of the library in native C++ to make it fast. The goal is to make it a few hundred millisecond filter times for a dataset with 1M entries. This performance is helpful in Atom's fuzzy finder to open files from large projects such as Chrome/Mozilla.
+- Zadeh is a rewrite of the library in native C++ to make it fast. The goal is to make it a few hundred millisecond filter times for a dataset with 1M entries. This performance is helpful in Atom's fuzzy finder to open files from large projects such as Chrome/Mozilla.
 
-### Extra featuers
+### Extra features
 
-Fuzzaldrin-plus-fast:
+Zadeh:
 
 - provides `filterTree` function which allows to fuzzy filter text in nested tree-like objects.
 - allows setting the candidates only once using `ArrayFilterer` and `TreeFilterer` classes, and then, perform `filter` multiple times. This is much more efficient than calling the `filter` or `filterTree` functions directly every time.
 
 # How performance is improved?
 
-Fuzzaldrin-plus-fast achieves 10x-20x performance improvement over Fuzzaldrin plus for chromium project with 300K files. This high performance is achieved using the following techniques.
+Zadeh achieves 10x-20x performance improvement over Fuzzaldrin plus for chromium project with 300K files. This high performance is achieved using the following techniques.
 
 - Converting Javascript/CoffeeScript code to native C++ bindings provides 4x performance benefit.
 - Use multiple threads to parallelize computation to achieve another 4x performance benefit. Currently, up to 8 threads are used if there are more than 10K candidates to filter.
@@ -34,19 +34,19 @@ API is backward compatible with Fuzzaldrin and Fuzzaldrin-plus. Additional funct
 Installation:
 
 ```sh
-npm install fuzzaldrin-plus-fast
+npm install zadeh
 ```
 
 To import all the functions:
 
 ```js
-import * as fuzzaldrin from "fuzzaldrin-plus-fast"
+import * as zadeh from "zadeh"
 ```
 
 or
 
 ```js
-const fuzzaldrin = require("fuzzaldrin-plus-fast")
+const zadeh = require("zadeh")
 ```
 
 ### filter(candidates, query, options = {})
@@ -60,7 +60,7 @@ Sort and filter the given candidates by matching them against the given query.
 Returns an array of candidates sorted by best match against the query.
 
 ```js
-const { filter } = require('fuzzaldrin-plus-fast')
+const { filter } = require('zadeh')
 
 // With an array of strings
 let candidates = ['Call', 'Me', 'Maybe']
@@ -103,7 +103,7 @@ export class ArrayFilterer<T> {
 Example:
 
 ```Javascript
-const { ArrayFilterer } = require('fuzzaldrin-plus-fast')
+const { ArrayFilterer } = require('zadeh')
 
 const arrayFilterer = new ArrayFilterer()
 arrayFilterer.setCandidates(['Call', 'Me', 'Maybe']) // set candidates only once
@@ -126,7 +126,7 @@ A **tree object** is an object in which each entry stores the data in its dataKe
 - `returns` An array of candidate objects in form of `{data, index, level}` sorted by best match against the query. Each objects has the address of the object in the tree using `index` and `level`.
 
 ```js
-const { filterTree } = require("fuzzaldrin-plus-fast")
+const { filterTree } = require("zadeh")
 
 candidates = [
   { data: "bye1", children: [{ data: "hello" }] },
@@ -170,7 +170,7 @@ export class TreeFilterer<T> {
 Example:
 
 ```Javascript
-const { TreeFilterer } = require('fuzzaldrin-plus-fast')
+const { TreeFilterer } = require('zadeh')
 
 const arrayFilterer = new TreeFilterer()
 
@@ -194,7 +194,7 @@ Score the given string against the given query.
 - `query` - The query to score the string against.
 
 ```js
-const { score } = require('fuzzaldrin-plus-fast')
+const { score } = require('zadeh')
 
 score('Me', 'me')    # 0.17099999999999999
 score('Maybe', 'me') # 0.0693
@@ -205,7 +205,7 @@ score('Maybe', 'me') # 0.0693
 Gives an array of indices at which the query matches the given string
 
 ```js
-const { match } = require("fuzzaldrin-plus-fast")
+const { match } = require("zadeh")
 
 match("Hello World", "he") // [0, 1]
 match("Hello World", "wor") // [6, 7, 8]

--- a/benchmark/benchmark-large.js
+++ b/benchmark/benchmark-large.js
@@ -3,7 +3,7 @@ const fs = require("fs")
 const path = require("path")
 const { elapsed_time, start_timer } = require("./testutils")
 
-const FuzzaldrinPlusFast = require("../node-dist")
+const Zadeh = require("../node-dist")
 const legacy = require("fuzzaldrin-plus")
 
 const lines = fs.readFileSync(path.join(__dirname, "data-large.txt"), "utf8").trim().split("\n")
@@ -14,8 +14,8 @@ const dict = lines.map((item) => {
   }
 })
 
-const fuzzaldrinplusfast = FuzzaldrinPlusFast.New()
-fuzzaldrinplusfast.setCandidates(lines)
+const zadeh = Zadeh.New()
+zadeh.setCandidates(lines)
 
 const two_letter_tests = [
   "dp",
@@ -71,14 +71,14 @@ elapsed_time(t1, "TwoLetter _legacy_")
 
 const t2 = start_timer()
 for (const query of two_letter_tests)
-  FuzzaldrinPlusFast.filter(lines, query, {
+  Zadeh.filter(lines, query, {
     maxResults: 10,
   })
 elapsed_time(t2, "TwoLetter direct filter")
 
 const t3 = start_timer()
 for (const query of two_letter_tests)
-  fuzzaldrinplusfast.filter(query, {
+  zadeh.filter(query, {
     maxResults: 10,
   })
 elapsed_time(t3, "TwoLetter setCandidates")
@@ -94,14 +94,14 @@ elapsed_time(t4, "ThreeLetter _legacy_")
 
 const t5 = start_timer()
 for (const query of three_letter_tests)
-  FuzzaldrinPlusFast.filter(lines, query, {
+  Zadeh.filter(lines, query, {
     maxResults: 10,
   })
 elapsed_time(t5, "ThreeLetter direct filter")
 
 const t6 = start_timer()
 for (const query of three_letter_tests)
-  fuzzaldrinplusfast.filter(query, {
+  zadeh.filter(query, {
     maxResults: 10,
   })
 elapsed_time(t6, "ThreeLetter setCandidates")
@@ -110,7 +110,7 @@ console.log("======")
 
 const t7 = start_timer()
 for (const query of two_letter_tests)
-  FuzzaldrinPlusFast.filter(dict, query, {
+  Zadeh.filter(dict, query, {
     maxResults: 10,
     key: "key",
   })
@@ -118,7 +118,7 @@ elapsed_time(t7, "TwoLetter keybased filter")
 
 const t8 = start_timer()
 for (const query of three_letter_tests)
-  FuzzaldrinPlusFast.filter(dict, query, {
+  Zadeh.filter(dict, query, {
     maxResults: 10,
     key: "key",
   })
@@ -127,7 +127,7 @@ elapsed_time(t8, "ThreeLetter keybased filter")
 console.log("======")
 
 const t9 = start_timer()
-let obj = FuzzaldrinPlusFast.New()
+let obj = Zadeh.New()
 obj.setCandidates(lines)
 elapsed_time(t9, "setCandidates")
 
@@ -148,7 +148,7 @@ elapsed_time(t11, "ThreeLetter filter")
 console.log("======")
 
 const t12 = start_timer()
-obj = FuzzaldrinPlusFast.New()
+obj = Zadeh.New()
 obj.setCandidates(dict, {
   key: "key",
 })

--- a/benchmark/benchmark-small.js
+++ b/benchmark/benchmark-small.js
@@ -3,7 +3,7 @@ const fs = require("fs")
 const path = require("path")
 const testutils = require("./testutils")
 
-const fuzzaldrinPlus = require("../node-dist")
+const Zadeh = require("../node-dist")
 const legacy = require("fuzzaldrin-plus")
 
 const lines = fs.readFileSync(path.join(__dirname, "data-small.txt"), "utf8").trim().split("\n")
@@ -15,7 +15,7 @@ const mitigation = {
 }
 
 // warmup + compile
-fuzzaldrinPlus.filter(lines, "index", forceAllMatch)
+Zadeh.filter(lines, "index", forceAllMatch)
 legacy.filter(lines, "index")
 
 testutils.doFilterTest(null, lines, "nm")

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -3,7 +3,7 @@ const fs = require("fs")
 const path = require("path")
 const { start_timer, elapsed_time, doFilterTest } = require("./testutils")
 
-const fuzzaldrinPlus = require("../node-dist")
+const Zadeh = require("../node-dist")
 const legacy = require("fuzzaldrin-plus")
 
 const lines = fs.readFileSync(path.join(__dirname, "data.txt"), "utf8").trim().split("\n")
@@ -15,7 +15,7 @@ const mitigation = {
 }
 
 // warmup + compile
-fuzzaldrinPlus.filter(lines, "index", forceAllMatch)
+Zadeh.filter(lines, "index", forceAllMatch)
 legacy.filter(lines, "index")
 
 doFilterTest("~10% of results are positive, mix exact & fuzzy", lines, "index")
@@ -29,9 +29,9 @@ doFilterTest("~98% of results + Fuzzy match, [Worst case but shorter string]", l
 
 const query = "index"
 const t1 = start_timer()
-const prepared = fuzzaldrinPlus.prepareQuery(query)
+const prepared = Zadeh.prepareQuery(query)
 for (const line of lines) {
-  fuzzaldrinPlus.match(line, query, {
+  Zadeh.match(line, query, {
     preparedQuery: prepared,
   })
 }
@@ -39,7 +39,7 @@ elapsed_time(t1, `Matching ${lines.length} results for 'index' (Prepare in advan
 
 const t2 = start_timer()
 for (const line of lines) {
-  fuzzaldrinPlus.match(line, query)
+  Zadeh.match(line, query)
 }
 elapsed_time(t2, `Matching ${lines.length} results for 'index' (cache)`)
 // replace by 'prepQuery ?= scorer.prepQuery(query)' to test without cache.

--- a/benchmark/result.txt
+++ b/benchmark/result.txt
@@ -1,107 +1,107 @@
-aminy@LAPTOP-DHBEBJRL  ~\Documents\GitHub\JavaScript\@atom-ide-community\fuzzaldrin-plus-fast   master ≣   [22:48]
+aminy@LAPTOP-DHBEBJRL  ~\Documents\GitHub\JavaScript\@atom-ide-community\zadeh   master ≣   [22:48]
 ❯ pnpm benchmark
 
-> fuzzaldrin-plus-fast@1.2.3 benchmark C:\Users\aminy\Documents\GitHub\JavaScript\@atom-ide-community\fuzzaldrin-plus-fast
+> zadeh@1.2.3 benchmark C:\Users\aminy\Documents\GitHub\JavaScript\@atom-ide-community\zadeh
 > npm run benchmark:small && npm run benchmark:regular && npm run benchmark:large && npm run benchmark:tree
 
 
-> fuzzaldrin-plus-fast@1.2.3 benchmark:small C:\Users\aminy\Documents\GitHub\JavaScript\@atom-ide-community\fuzzaldrin-plus-fast
+> zadeh@1.2.3 benchmark:small C:\Users\aminy\Documents\GitHub\JavaScript\@atom-ide-community\zadeh
 > node benchmark/benchmark-small.js
 
 ====== Running test - query:nm ======
-fuzzaldrin-plus-fast vs. legacy:                                                    0.19 ms  |   0.52 ms
+zadeh vs. legacy:                                                    0.19 ms  |   0.52 ms
 length of the result: 100, length of the lines: 100
 
 ====== Running test - query:npm ======
-fuzzaldrin-plus-fast vs. legacy:                                                    0.15 ms  |   3.77 ms
+zadeh vs. legacy:                                                    0.15 ms  |   3.77 ms
 length of the result: 55, length of the lines: 100
 
 ====== Running test - query:node ======
-fuzzaldrin-plus-fast vs. legacy:                                                    0.15 ms  |   1.34 ms
+zadeh vs. legacy:                                                    0.15 ms  |   1.34 ms
 length of the result: 100, length of the lines: 100
 
 ====== Running test - query:grunt ======
-fuzzaldrin-plus-fast vs. legacy:                                                    0.2 ms  |   0.26 ms
+zadeh vs. legacy:                                                    0.2 ms  |   0.26 ms
 length of the result: 33, length of the lines: 100
 
 ====== Running test - query:html ======
-fuzzaldrin-plus-fast vs. legacy:                                                    0.1 ms  |   0.45 ms
+zadeh vs. legacy:                                                    0.1 ms  |   0.45 ms
 length of the result: 10, length of the lines: 100
 
 ====== Running test - query:doc ======
-fuzzaldrin-plus-fast vs. legacy:                                                    0.23 ms  |   3.71 ms
+zadeh vs. legacy:                                                    0.23 ms  |   3.71 ms
 length of the result: 87, length of the lines: 100
 
 ====== Running test - query:cli ======
-fuzzaldrin-plus-fast vs. legacy:                                                    0.89 ms  |   1.63 ms
+zadeh vs. legacy:                                                    0.89 ms  |   1.63 ms
 length of the result: 57, length of the lines: 100
 
 ====== Running test - query:js ======
-fuzzaldrin-plus-fast vs. legacy:                                                    0.17 ms  |   0.44 ms
+zadeh vs. legacy:                                                    0.17 ms  |   0.44 ms
 length of the result: 60, length of the lines: 100
 
 ====== Running test - query:jas ======
-fuzzaldrin-plus-fast vs. legacy:                                                    0.15 ms  |   0.5 ms
+zadeh vs. legacy:                                                    0.15 ms  |   0.5 ms
 length of the result: 19, length of the lines: 100
 
 ====== Running test - query:mine ======
-fuzzaldrin-plus-fast vs. legacy:                                                    0.24 ms  |   2.48 ms
+zadeh vs. legacy:                                                    0.24 ms  |   2.48 ms
 length of the result: 65, length of the lines: 100
 
 ====== Running test - query:stream ======
-fuzzaldrin-plus-fast vs. legacy:                                                    0.15 ms  |   1.26 ms
+zadeh vs. legacy:                                                    0.15 ms  |   1.26 ms
 length of the result: 19, length of the lines: 100
 
 
-> fuzzaldrin-plus-fast@1.2.3 benchmark:regular C:\Users\aminy\Documents\GitHub\JavaScript\@atom-ide-community\fuzzaldrin-plus-fast
+> zadeh@1.2.3 benchmark:regular C:\Users\aminy\Documents\GitHub\JavaScript\@atom-ide-community\zadeh
 > node benchmark/benchmark.js
 
 ====== Running test - query:index ======
 ~10% of results are positive, mix exact & fuzzy
-fuzzaldrin-plus-fast vs. legacy:                                                    26.6 ms  |   42.98 ms
+zadeh vs. legacy:                                                    26.6 ms  |   42.98 ms
 length of the result: 6168, length of the lines: 66672
 
 ====== Running test - query:indx ======
 ~10% of results are positive, Fuzzy match
-fuzzaldrin-plus-fast vs. legacy:                                                    26.48 ms  |   48.69 ms
+zadeh vs. legacy:                                                    26.48 ms  |   48.69 ms
 length of the result: 6192, length of the lines: 66672
 
 ====== Running test - query:walkdr ======
 ~1% of results are positive, fuzzy
-fuzzaldrin-plus-fast vs. legacy:                                                    23.62 ms  |   15.56 ms
+zadeh vs. legacy:                                                    23.62 ms  |   15.56 ms
 length of the result: 504, length of the lines: 66672
-                                                                            fuzzaldrin-plus-fast is SLOWER
+                                                                            zadeh is SLOWER
 
 ====== Running test - query:node ======
 ~98% of results are positive, mostly Exact match
-fuzzaldrin-plus-fast vs. legacy:                                                    40.91 ms  |   66.81 ms
+zadeh vs. legacy:                                                    40.91 ms  |   66.81 ms
 length of the result: 65136, length of the lines: 66672
 
 ====== Running test - query:nm ======
 ~98% of results are positive, Acronym match
-fuzzaldrin-plus-fast vs. legacy:                                                    38.32 ms  |   61.2 ms
+zadeh vs. legacy:                                                    38.32 ms  |   61.2 ms
 length of the result: 65208, length of the lines: 66672
 
 ====== Running test - query:nm ======
 ~98% of results + Fuzzy match, [Worst case scenario]
-fuzzaldrin-plus-fast vs. legacy:                                                    38.38 ms  |   51.83 ms
+zadeh vs. legacy:                                                    38.38 ms  |   51.83 ms
 length of the result: 65208, length of the lines: 66672
 
 ====== Running test - query:nm ======
 ~98% of results + Fuzzy match, [Mitigation]
-fuzzaldrin-plus-fast vs. legacy:                                                    39.13 ms  |   52.08 ms
+zadeh vs. legacy:                                                    39.13 ms  |   52.08 ms
 length of the result: 65208, length of the lines: 66672
 
 ====== Running test - query:ndem ======
 ~98% of results + Fuzzy match, [Worst case but shorter string]
-fuzzaldrin-plus-fast vs. legacy:                                                    43.48 ms  |   207.84 ms
+zadeh vs. legacy:                                                    43.48 ms  |   207.84 ms
 length of the result: 65124, length of the lines: 66672
 
 Matching 66672 results for 'index' (Prepare in advance) took                           284.09 ms
 Matching 66672 results for 'index' (cache) took                                        272.74 ms
 Matching 66672 results for 'index' (_legacy_) took                                     80.52 ms
 
-> fuzzaldrin-plus-fast@1.2.3 benchmark:large C:\Users\aminy\Documents\GitHub\JavaScript\@atom-ide-community\fuzzaldrin-plus-fast
+> zadeh@1.2.3 benchmark:large C:\Users\aminy\Documents\GitHub\JavaScript\@atom-ide-community\zadeh
 > node benchmark/benchmark-large.js
 
 TwoLetter _legacy_ took                                                                12058.96 ms
@@ -123,7 +123,7 @@ setCandidates keybased took                                                     
 TwoLetter keybased filter took                                                         392.12 ms
 ThreeLetter keybased filter took                                                       399.40 ms
 
-> fuzzaldrin-plus-fast@1.2.3 benchmark:tree C:\Users\aminy\Documents\GitHub\JavaScript\@atom-ide-community\fuzzaldrin-plus-fast
+> zadeh@1.2.3 benchmark:tree C:\Users\aminy\Documents\GitHub\JavaScript\@atom-ide-community\zadeh
 > node benchmark/benchmark-tree.js
 
 TreeFilterer.setCandidates: took                                                       2.03 ms

--- a/benchmark/testutils.js
+++ b/benchmark/testutils.js
@@ -1,4 +1,4 @@
-const fuzzaldrinPlus = require("../node-dist")
+const zadeh = require("../node-dist")
 const legacy = require("fuzzaldrin-plus")
 
 let performance = null
@@ -47,7 +47,7 @@ exports.elapsed_time = elapsed_time
 function doFilterTest(test_name, lines, query, params) {
   console.log(`====== Running test - query:${query} ======`)
   const timer_start_time = start_timer()
-  const res_actual = fuzzaldrinPlus.filter(lines, query, params)
+  const res_actual = zadeh.filter(lines, query, params)
   const elapsed = elapsed_time(timer_start_time)
 
   const timer_start_time_legacy = start_timer()
@@ -67,11 +67,11 @@ function doFilterTest(test_name, lines, query, params) {
   if (test_name) {
     console.log(test_name)
   }
-  console.log(`fuzzaldrin-plus-fast vs. legacy: ${" ".repeat(50)} ${elapsed} ms  |   ${elapsed_legacy} ms`)
+  console.log(`zadeh vs. legacy: ${" ".repeat(50)} ${elapsed} ms  |   ${elapsed_legacy} ms`)
   console.log(`length of the result: ${res_actual.length}, length of the lines: ${lines.length}`)
 
   if (elapsed > elapsed_legacy) {
-    console.error(`${" ".repeat(75)} fuzzaldrin-plus-fast is SLOWER`)
+    console.error(`${" ".repeat(75)} zadeh is SLOWER`)
   }
   console.log("")
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,7 @@
 # Note: C++ standard is repeated in configurations multiple times for different configurations
 {
   "targets": [{
-      "target_name": "fuzzaldrinplusfast",
+      "target_name": "zadeh",
       "sources": [ "src/common.h", "src/options.h", "src/binding/node.cc", "src/binding/node.h", "src/scorer.h", "src/path_scorer.h", "src/filter.h", "src/query.h", "src/matcher.h",  "src/binding/tree.h" ],
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "fuzzaldrin-plus-fast",
+  "name": "zadeh",
   "version": "1.2.4",
-  "description": "Fuzzaldrin plus - fast using native c bindings",
+  "description": "Blazing fast library for fuzzy filtering, matching, and other fuzzy things!",
   "main": "./node-dist.js",
   "node": "./node-dist.js",
-  "types": "./types/fuzzaldrin-plus-fast.d.ts",
+  "types": "./types/zadeh.d.ts",
   "scripts": {
     "format": "prettier --write . && clang-format -i src/*.cc src/*.h",
     "tidy": "clang-tidy src/*.cc src/*.h",
@@ -69,12 +69,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/atom-ide-community/fuzzaldrin-plus-fast.git"
+    "url": "https://github.com/atom-ide-community/zadeh.git"
   },
   "author": "Rajendran T",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/atom-ide-community/fuzzaldrin-plus-fast/issues"
+    "url": "https://github.com/atom-ide-community/zadeh/issues"
   },
-  "homepage": "https://github.com/atom-ide-community/fuzzaldrin-plus-fast"
+  "homepage": "https://github.com/atom-ide-community/zadeh"
 }

--- a/spec/filter-options-spec.coffee
+++ b/spec/filter-options-spec.coffee
@@ -1,14 +1,14 @@
-fuzzaldrinplusfast = require('../node-dist');
+zadeh = require('../node-dist');
 fuzzaldrinExpected = require 'fuzzaldrin-plus'
 
 score_test = (candidate, query, options={}) ->
   expected = fuzzaldrinExpected.score(candidate, query, options)
-  actual = fuzzaldrinplusfast.score(candidate, query, options)
+  actual = zadeh.score(candidate, query, options)
   # expect(actual).toEqual(expected) # Tests are disabled for now.
 
 filter_test = (candidates, query, options={}) ->
   expected = fuzzaldrinExpected.filter(candidates, query, options)
-  actual = fuzzaldrinplusfast.filter(candidates, query, options)
+  actual = zadeh.filter(candidates, query, options)
   expect(actual).toEqual(expected)
 
 score_test_with_options = (options) ->
@@ -61,14 +61,14 @@ describe "filtering", ->
   describe "returns the same candidates as filtered by fuzzaldrin-plus", ->
 
     it "with default options", ->
-      expect(fuzzaldrinplusfast.filter(['ab', 'abc', 'cd', 'de'], 'a')).toEqual(['ab', 'abc'])
-      expect(fuzzaldrinplusfast.filter(['ab', 'abc', 'cd', 'de'], 'b')).toEqual(['ab', 'abc'])
-      expect(fuzzaldrinplusfast.filter(['ab', 'abc', 'cd', 'de'], 'c')).toEqual(['cd', 'abc',])
+      expect(zadeh.filter(['ab', 'abc', 'cd', 'de'], 'a')).toEqual(['ab', 'abc'])
+      expect(zadeh.filter(['ab', 'abc', 'cd', 'de'], 'b')).toEqual(['ab', 'abc'])
+      expect(zadeh.filter(['ab', 'abc', 'cd', 'de'], 'c')).toEqual(['cd', 'abc',])
 
     it "honors maxResults in options", ->
-      expect(fuzzaldrinplusfast.filter(['ab', 'abc', 'abcd', 'abcdde'], 'a', maxResults: 1)).toEqual(['ab'])
-      expect(fuzzaldrinplusfast.filter(['ab', 'abc', 'abcd', 'abcdde'], 'a', maxResults: 2)).toEqual(['ab', 'abc'])
-      expect(fuzzaldrinplusfast.filter(['ab', 'abc', 'abcd', 'abcdde'], 'c', maxResults: 2)).toEqual(['abc', 'abcd'])
+      expect(zadeh.filter(['ab', 'abc', 'abcd', 'abcdde'], 'a', maxResults: 1)).toEqual(['ab'])
+      expect(zadeh.filter(['ab', 'abc', 'abcd', 'abcdde'], 'a', maxResults: 2)).toEqual(['ab', 'abc'])
+      expect(zadeh.filter(['ab', 'abc', 'abcd', 'abcdde'], 'c', maxResults: 2)).toEqual(['abc', 'abcd'])
 
     it "candidates are able to be indexed by a given key", ->
       candidates = [
@@ -77,18 +77,18 @@ describe "filtering", ->
         {uri: '/usr/sbin/find', fname: 'find'},
         {uri: '/usr/local/bin/git', fname: 'git'},
       ]
-      expect(fuzzaldrinplusfast.filter(candidates, 'i', key: 'fname')).toEqual([candidates[3], candidates[2], candidates[1]])
+      expect(zadeh.filter(candidates, 'i', key: 'fname')).toEqual([candidates[3], candidates[2], candidates[1]])
 
     it "candidates with duplicate values when indexed by key are returned properly", ->
       candidates = [
         {uri: '/usr/bin/ls', fname: 'ls'},
         {uri: '/usr/sbin/ls', fname: 'ls'}
       ]
-      expect(fuzzaldrinplusfast.filter(candidates, 'l', key: 'fname')).toEqual([candidates[0], candidates[1]])
+      expect(zadeh.filter(candidates, 'l', key: 'fname')).toEqual([candidates[0], candidates[1]])
 
   describe "filtering by creating an object", ->
     it "with default options", ->
-      obj = fuzzaldrinplusfast.New()
+      obj = zadeh.New()
       obj.setCandidates ['ab', 'abc', 'cd', 'de']
       expect(obj.filter('a')).toEqual(['ab', 'abc'])
       expect(obj.filter('b')).toEqual(['ab', 'abc'])
@@ -101,7 +101,7 @@ describe "filtering", ->
         {uri: '/usr/sbin/find', fname: 'find'},
         {uri: '/usr/local/bin/git', fname: 'git'},
       ]
-      obj = fuzzaldrinplusfast.New()
+      obj = zadeh.New()
       obj.setCandidates candidates, key: 'fname'
       expect(obj.filter('i')).toEqual([candidates[3], candidates[2], candidates[1]])
 
@@ -110,6 +110,6 @@ describe "filtering", ->
         {uri: '/usr/bin/ls', fname: 'ls'},
         {uri: '/usr/sbin/ls', fname: 'ls'}
       ]
-      obj = fuzzaldrinplusfast.New()
+      obj = zadeh.New()
       obj.setCandidates candidates, key: 'fname'
       expect(obj.filter('l')).toEqual([candidates[0], candidates[1]])

--- a/src/binding/node.cc
+++ b/src/binding/node.cc
@@ -2,7 +2,7 @@
 
 #include "node.h"
 
-Napi::Value Fuzzaldrin::Filter(const Napi::CallbackInfo &info) {
+Napi::Value Zadeh::Filter(const Napi::CallbackInfo &info) {
     auto res = Napi::Array::New(info.Env());
     if (info.Length() != 4 || !info[0].IsString() || !info[1].IsNumber() || !info[2].IsBoolean() || !info[3].IsBoolean()) {
         Napi::TypeError::New(info.Env(), "Invalid arguments for Filter").ThrowAsJavaScriptException();
@@ -25,7 +25,7 @@ Napi::Value Fuzzaldrin::Filter(const Napi::CallbackInfo &info) {
     return res;
 }
 
-Napi::Value Fuzzaldrin::setArrayFiltererCandidates(const Napi::CallbackInfo &info) {
+Napi::Value Zadeh::setArrayFiltererCandidates(const Napi::CallbackInfo &info) {
     if (info.Length() != 1 || !info[0].IsArray()) {
         Napi::TypeError::New(info.Env(), "Invalid arguments for setArrayFiltererCandidates").ThrowAsJavaScriptException();
         return Napi::Boolean();
@@ -55,7 +55,7 @@ Napi::Value Fuzzaldrin::setArrayFiltererCandidates(const Napi::CallbackInfo &inf
     return Napi::Boolean();
 }
 
-Napi::Value Fuzzaldrin::setTreeFiltererCandidates(const Napi::CallbackInfo &info) {
+Napi::Value Zadeh::setTreeFiltererCandidates(const Napi::CallbackInfo &info) {
     // parse arguments
     if (info.Length() != 3
         || !info[0].IsArray()
@@ -97,7 +97,7 @@ Napi::Value Fuzzaldrin::setTreeFiltererCandidates(const Napi::CallbackInfo &info
 }
 
 /** (query: string, maxResults: number, usePathScoring: bool, useExtensionBonus: bool) */
-Napi::Value Fuzzaldrin::FilterTree(const Napi::CallbackInfo &info) {
+Napi::Value Zadeh::FilterTree(const Napi::CallbackInfo &info) {
     // parse arguments
     if (info.Length() != 4
         || !info[0].IsString()
@@ -193,22 +193,22 @@ Napi::String wrap(const Napi::CallbackInfo &info) {
     return Napi::String::New(info.Env(), res);
 }
 
-Napi::Object Fuzzaldrin::Init(Napi::Env env, Napi::Object exports) {
+Napi::Object Zadeh::Init(Napi::Env env, Napi::Object exports) {
     Napi::HandleScope scope(env);
 
-    // define Fuzzaldrin class in JS
+    // define Zadeh class in JS
     const auto func = DefineClass(
       env,
-      "Fuzzaldrin",
+      "Zadeh",
       { // member functions in JS
-        InstanceMethod("filter", &Fuzzaldrin::Filter),
-        InstanceMethod("filterTree", &Fuzzaldrin::FilterTree),
-        InstanceMethod("setArrayFiltererCandidates", &Fuzzaldrin::setArrayFiltererCandidates),
-        InstanceMethod("setTreeFiltererCandidates", &Fuzzaldrin::setTreeFiltererCandidates)
+        InstanceMethod("filter", &Zadeh::Filter),
+        InstanceMethod("filterTree", &Zadeh::FilterTree),
+        InstanceMethod("setArrayFiltererCandidates", &Zadeh::setArrayFiltererCandidates),
+        InstanceMethod("setTreeFiltererCandidates", &Zadeh::setTreeFiltererCandidates)
 
       });
-    // export Fuzzaldrin class to JS
-    exports.Set("Fuzzaldrin", func);
+    // export Zadeh class to JS
+    exports.Set("Zadeh", func);
 
     exports.Set("score", Napi::Function::New(env, score));
     exports.Set("match", Napi::Function::New(env, match));
@@ -217,7 +217,7 @@ Napi::Object Fuzzaldrin::Init(Napi::Env env, Napi::Object exports) {
 }
 
 Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
-    return Fuzzaldrin::Init(env, exports);
+    return Zadeh::Init(env, exports);
 }
 
 NODE_API_MODULE(NODE_GYP_MODULE_NAME, InitAll)

--- a/src/binding/node.h
+++ b/src/binding/node.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef FUZZALDRIN_H
-#define FUZZALDRIN_H
+#ifndef Zadeh_H
+#define Zadeh_H
 
 #include <napi.h>
 
@@ -17,10 +17,10 @@
 // Converted from the example at
 // https://github.com/nodejs/node-addon-examples/blob/master/6_object_wrap/node-addon-api/
 
-class Fuzzaldrin : public Napi::ObjectWrap<Fuzzaldrin> {
+class Zadeh : public Napi::ObjectWrap<Zadeh> {
   public:
     static Napi::Object Init(Napi::Env env, Napi::Object exports);
-    explicit Fuzzaldrin(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Fuzzaldrin>(info) {}
+    explicit Zadeh(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Zadeh>(info) {}
 
     Napi::Value Filter(const Napi::CallbackInfo &info);
     Napi::Value setArrayFiltererCandidates(const Napi::CallbackInfo &info);
@@ -33,4 +33,4 @@ class Fuzzaldrin : public Napi::ObjectWrap<Fuzzaldrin> {
     Tree _tree;
 };
 
-#endif    // FUZZALDRIN_H
+#endif    // Zadeh_H

--- a/src/binding/node.js
+++ b/src/binding/node.js
@@ -17,7 +17,7 @@ function parseOptions(options, query) {
 
 export class ArrayFilterer {
   constructor() {
-    this.obj = new binding.Fuzzaldrin()
+    this.obj = new binding.Zadeh()
   }
 
   setCandidates(candidates, dataKey = undefined) {
@@ -65,7 +65,7 @@ export function filter(candidates, query, options = {}) {
 
 export class TreeFilterer {
   constructor() {
-    this.obj = new binding.Fuzzaldrin()
+    this.obj = new binding.Zadeh()
   }
 
   setCandidates(candidates, dataKey = "data", childrenKey = "children") {

--- a/src/binding/tree.h
+++ b/src/binding/tree.h
@@ -1,5 +1,5 @@
-#ifndef Fuzzaldrin_tree_h_
-#define Fuzzaldrin_tree_h_
+#ifndef Zadeh_tree_h_
+#define Zadeh_tree_h_
 
 #include <optional>
 #include "../common.h"
@@ -75,4 +75,4 @@ struct Tree {
     }
 };
 
-#endif    // Fuzzaldrin_tree_h_
+#endif    // Zadeh_tree_h_

--- a/src/common.h
+++ b/src/common.h
@@ -1,5 +1,5 @@
-#ifndef Fuzzaldrin_common_h_
-#define Fuzzaldrin_common_h_
+#ifndef Zadeh_common_h_
+#define Zadeh_common_h_
 
 #include <vector>
 #include <set>
@@ -64,4 +64,4 @@ Element ToUpper(const Element &s) {
     return snew;
 }
 
-#endif    // Fuzzaldrin_common_h_
+#endif    // Zadeh_common_h_

--- a/src/filter.h
+++ b/src/filter.h
@@ -1,5 +1,5 @@
-#ifndef Fuzzaldrin_filter_h_
-#define Fuzzaldrin_filter_h_
+#ifndef Zadeh_filter_h_
+#define Zadeh_filter_h_
 
 #include <queue>
 #include <functional>

--- a/src/matcher.h
+++ b/src/matcher.h
@@ -1,5 +1,5 @@
-#ifndef Fuzzaldrin_matcher_h_
-#define Fuzzaldrin_matcher_h_
+#ifndef Zadeh_matcher_h_
+#define Zadeh_matcher_h_
 
 
 #include <iterator>
@@ -10,7 +10,7 @@
 #include "query.h"
 
 //----------------------------------------------------------------------
-// Align sequence (used for fuzzaldrin.match)
+// Align sequence (used for zadeh.match)
 // Return position of subject characters that match query.
 //
 // Follow closely scorer.computeScore.

--- a/src/options.h
+++ b/src/options.h
@@ -1,5 +1,5 @@
-#ifndef Fuzzaldrin_options_h_
-#define Fuzzaldrin_options_h_
+#ifndef Zadeh_options_h_
+#define Zadeh_options_h_
 
 #include "common.h"
 

--- a/src/path_scorer.h
+++ b/src/path_scorer.h
@@ -1,5 +1,5 @@
-#ifndef Fuzzaldrin_path_scorer_h_
-#define Fuzzaldrin_path_scorer_h_
+#ifndef Zadeh_path_scorer_h_
+#define Zadeh_path_scorer_h_
 
 
 #include "common.h"

--- a/src/query.h
+++ b/src/query.h
@@ -1,5 +1,5 @@
-#ifndef Fuzzaldrin_query_h_
-#define Fuzzaldrin_query_h_
+#ifndef Zadeh_query_h_
+#define Zadeh_query_h_
 
 #include "common.h"
 #include "path_scorer.h"

--- a/src/scorer.h
+++ b/src/scorer.h
@@ -1,5 +1,5 @@
-#ifndef Fuzzaldrin_scorer_h_
-#define Fuzzaldrin_scorer_h_
+#ifndef Zadeh_scorer_h_
+#define Zadeh_scorer_h_
 
 #include <cmath>
 #include <iostream> // cerr


### PR DESCRIPTION
I am changing the library name to Zadeh as a reference to [Zadeh](https://en.wikipedia.org/wiki/Lotfi_A._Zadeh), the inventor of fuzzy logic.

Fixes https://github.com/atom-ide-community/fuzzaldrin-plus-fast/issues/51

This deprecates the old npm package (no more updates). The new package will be published starting from version 2.0.0