### PR TITLE
fix: move validators from C++ to TypeScript

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,6 +1,0 @@
-{
-  "presets": ["babel-preset-atomic"],
-  "plugins": [],
-  "exclude": "node_modules/**",
-  "sourceMap": "inline"
-}

--- a/benchmark/result.txt
+++ b/benchmark/result.txt
@@ -1,149 +1,142 @@
-
-> zadeh@2.1.0 benchmark C:\Users\aminy\Documents\GitHub\JavaScript\@atom-ide-community\zadeh
-> npm run benchmark.small && npm run benchmark.regular && npm run benchmark.large && npm run benchmark.tree
-
-
-> zadeh@2.1.0 benchmark.small
+> zadeh@2.1.0 benchmark.small C:\Users\aminy\Documents\GitHub\JavaScript\@atom-ide-community\zadeh
 > node benchmark/benchmark-small.js
 
 Zadeh: deprecated function. Use 'StringArrayFilterer' instead
 ====== Running test - query:nm ======
-zadeh vs. legacy:                                                    0.18 ms  |   0.46 ms
+zadeh vs. legacy:                                                    0.18 ms  |   0.47 ms
 length of the result: 100, length of the lines: 100
 
 ====== Running test - query:npm ======
-zadeh vs. legacy:                                                    0.16 ms  |   4.53 ms
+zadeh vs. legacy:                                                    0.14 ms  |   3.4 ms
 length of the result: 55, length of the lines: 100
 
 ====== Running test - query:node ======
-zadeh vs. legacy:                                                    0.19 ms  |   1.32 ms
+zadeh vs. legacy:                                                    0.16 ms  |   1.33 ms
 length of the result: 100, length of the lines: 100
 
 ====== Running test - query:grunt ======
-zadeh vs. legacy:                                                    0.12 ms  |   0.27 ms
+zadeh vs. legacy:                                                    0.31 ms  |   0.37 ms
 length of the result: 33, length of the lines: 100
 
 ====== Running test - query:html ======
-zadeh vs. legacy:                                                    0.11 ms  |   0.44 ms
+zadeh vs. legacy:                                                    0.1 ms  |   0.46 ms
 length of the result: 10, length of the lines: 100
 
 ====== Running test - query:doc ======
-zadeh vs. legacy:                                                    0.22 ms  |   3.7 ms
+zadeh vs. legacy:                                                    0.24 ms  |   3.57 ms
 length of the result: 87, length of the lines: 100
 
 ====== Running test - query:cli ======
-zadeh vs. legacy:                                                    0.18 ms  |   1.53 ms
+zadeh vs. legacy:                                                    0.37 ms  |   1.89 ms
 length of the result: 57, length of the lines: 100
 
 ====== Running test - query:js ======
-zadeh vs. legacy:                                                    0.17 ms  |   0.29 ms
+zadeh vs. legacy:                                                    0.18 ms  |   0.27 ms
 length of the result: 60, length of the lines: 100
 
 ====== Running test - query:jas ======
-zadeh vs. legacy:                                                    0.13 ms  |   0.49 ms
+zadeh vs. legacy:                                                    0.12 ms  |   0.47 ms
 length of the result: 19, length of the lines: 100
 
 ====== Running test - query:mine ======
-zadeh vs. legacy:                                                    0.43 ms  |   2.36 ms
+zadeh vs. legacy:                                                    0.18 ms  |   2.36 ms
 length of the result: 65, length of the lines: 100
 
 ====== Running test - query:stream ======
-zadeh vs. legacy:                                                    0.14 ms  |   1.23 ms
+zadeh vs. legacy:                                                    0.13 ms  |   1.1 ms
 length of the result: 19, length of the lines: 100
-
-
 > zadeh@2.1.0 benchmark.regular
 > node benchmark/benchmark.js
 
 Zadeh: deprecated function. Use 'StringArrayFilterer' instead
 ====== Running test - query:index ======
 ~10% of results are positive, mix exact & fuzzy
-zadeh vs. legacy:                                                    28.44 ms  |   43.49 ms
+zadeh vs. legacy:                                                    28.82 ms  |   43.34 ms
 length of the result: 6168, length of the lines: 66672
 
 ====== Running test - query:indx ======
 ~10% of results are positive, Fuzzy match
-zadeh vs. legacy:                                                    28.05 ms  |   48.44 ms
+zadeh vs. legacy:                                                    28.43 ms  |   49.1 ms
 length of the result: 6192, length of the lines: 66672
 
 ====== Running test - query:walkdr ======
 ~1% of results are positive, fuzzy
-zadeh vs. legacy:                                                    25.68 ms  |   15.69 ms
+zadeh vs. legacy:                                                    25.66 ms  |   15.74 ms
 length of the result: 504, length of the lines: 66672
                                                                             zadeh is SLOWER
 
 ====== Running test - query:node ======
 ~98% of results are positive, mostly Exact match
-zadeh vs. legacy:                                                    46.26 ms  |   67.55 ms
+zadeh vs. legacy:                                                    45.2 ms  |   67.57 ms
 length of the result: 65136, length of the lines: 66672
 
 ====== Running test - query:nm ======
 ~98% of results are positive, Acronym match
-zadeh vs. legacy:                                                    40.38 ms  |   66.45 ms
+zadeh vs. legacy:                                                    38.9 ms  |   69.47 ms
 length of the result: 65208, length of the lines: 66672
 
 ====== Running test - query:nm ======
 ~98% of results + Fuzzy match, [Worst case scenario]
-zadeh vs. legacy:                                                    39.3 ms  |   59.24 ms
+zadeh vs. legacy:                                                    39.56 ms  |   61.79 ms
 length of the result: 65208, length of the lines: 66672
 
 ====== Running test - query:nm ======
 ~98% of results + Fuzzy match, [Mitigation]
-zadeh vs. legacy:                                                    39.99 ms  |   55.26 ms
+zadeh vs. legacy:                                                    39.76 ms  |   55.73 ms
 length of the result: 65208, length of the lines: 66672
 
 ====== Running test - query:ndem ======
 ~98% of results + Fuzzy match, [Worst case but shorter string]
-zadeh vs. legacy:                                                    45.26 ms  |   207.97 ms
+zadeh vs. legacy:                                                    45.66 ms  |   206.9 ms
 length of the result: 65124, length of the lines: 66672
 
 Zadeh: prepareQuery is deprecated. There is no major benefit by precomputing something just for the query.
-Matching 66672 results for 'index' (Prepare in advance) took                           279.91 ms
-Matching 66672 results for 'index' (cache) took                                        282.02 ms
-Matching 66672 results for 'index' (_legacy_) took                                     83.31 ms
+Matching 66672 results for 'index' (Prepare in advance) took                           293.66 ms
+Matching 66672 results for 'index' (cache) took                                        279.56 ms
+Matching 66672 results for 'index' (_legacy_) took                                     82.57 ms
 
 > zadeh@2.1.0 benchmark.large
 > node benchmark/benchmark-large.js
 
-TwoLetter _legacy_ took                                                                10756.70 ms
+TwoLetter _legacy_ took                                                                10718.67 ms
 Zadeh: deprecated function. Use 'StringArrayFilterer' instead
-TwoLetter deprecated filter took                                                       3318.05 ms
-TwoLetter StringArrayFilterer.filter took                                              389.90 ms
+TwoLetter deprecated filter took                                                       3425.46 ms
+TwoLetter StringArrayFilterer.filter took                                              419.65 ms
 ======
-ThreeLetter _legacy_ took                                                              8667.04 ms
-ThreeLetter deprecated filter took                                                     3382.18 ms
-ThreeLetter StringArrayFilterer.filter took                                            391.64 ms
+ThreeLetter _legacy_ took                                                              8647.23 ms
+ThreeLetter deprecated filter took                                                     3505.40 ms
+ThreeLetter StringArrayFilterer.filter took                                            412.46 ms
 ======
-TwoLetter object filter took                                                           395.32 ms
-ThreeLetter object filter took                                                         390.56 ms
+TwoLetter object filter took                                                           426.80 ms
+ThreeLetter object filter took                                                         418.18 ms
 Zadeh: deprecated function. Use 'ObjectArrayFilterer' instead
-TwoLetter object deprecated filter took                                                4243.98 ms
-ThreeLetter object deprecated filter took                                              4697.41 ms
+TwoLetter object deprecated filter took                                                4077.01 ms
+ThreeLetter object deprecated filter took                                              4752.99 ms
 ======
-StringArrayFilterer constructor took                                                   224.09 ms
-TwoLetter StringArrayFilterer.filter took                                              407.53 ms
-ThreeLetter StringArrayFilterer.filter took                                            397.28 ms
+StringArrayFilterer constructor took                                                   235.95 ms
+TwoLetter StringArrayFilterer.filter took                                              418.53 ms
+ThreeLetter StringArrayFilterer.filter took                                            430.14 ms
 ======
-ObjectArrayFilterer constructor took                                                   236.27 ms
-TwoLetter ObjectArrayFilterer.filter took                                              410.62 ms
-ThreeLetter ObjectArrayFilterer.filter took                                            393.21 ms
+ObjectArrayFilterer constructor took                                                   234.18 ms
+TwoLetter ObjectArrayFilterer.filter took                                              414.06 ms
+ThreeLetter ObjectArrayFilterer.filter took                                            419.60 ms
 
 > zadeh@2.1.0 benchmark.tree
 > node benchmark/benchmark-tree.js
 
-TreeFilterer.setCandidates: took                                                       2.13 ms
+TreeFilterer.setCandidates: took                                                       2.18 ms
 TreeFilterer.filter text took                                                          0.62 ms
-TreeFilterer.filter dips took                                                          0.34 ms
-TreeFilterer.filter disp took                                                          0.26 ms
-TreeFilterer.filter txt took                                                           0.50 ms
-TreeFilterer.filter getBuffer took                                                     0.29 ms
+TreeFilterer.filter dips took                                                          0.30 ms
+TreeFilterer.filter disp took                                                          0.25 ms
+TreeFilterer.filter txt took                                                           0.43 ms
+TreeFilterer.filter getBuffer took                                                     0.32 ms
 
-TreeFilterer.filter average:                                                           0.402 ms
+TreeFilterer.filter average:                                                           0.384 ms
 
-filterTree text took                                                                   2.80 ms
-filterTree dips took                                                                   3.26 ms
-filterTree disp took                                                                   2.30 ms
-filterTree txt: took                                                                   3.80 ms
-filterTree getBuffer: took                                                             2.48 ms
+filterTree text took                                                                   2.82 ms
+filterTree dips took                                                                   2.48 ms
+filterTree disp took                                                                   2.41 ms
+filterTree txt: took                                                                   3.46 ms
+filterTree getBuffer: took                                                             2.50 ms
 
-filterTree average:                                                                    2.928 ms
+filterTree average:                                                                    2.734 ms

--- a/package.json
+++ b/package.json
@@ -48,23 +48,22 @@
     "node-gyp-build": "^4.2.3"
   },
   "devDependencies": {
-    "babel-preset-atomic": "^3.0.3",
     "coffeescript": "^2.5.1",
     "cross-env": "^7.0.3",
     "deep-equal": "^2.0.5",
-    "eslint": "^7.23.0",
-    "eslint-config-atomic": "^1.12.4",
+    "eslint": "^7.24.0",
+    "eslint-config-atomic": "^1.14.0",
     "fuzzaldrin-plus": "^0.6.0",
     "growl": ">=1.10.5",
     "jasmine": "^3.7.0",
     "jasmine-node": "^3.0.0",
-    "npm-check-updates": "11.3.0",
+    "npm-check-updates": "11.4.1",
     "prebuildify": "^4.1.2",
     "prettier-config-atomic": "^2.0.1",
-    "rollup": "^2.43.1",
-    "rollup-plugin-atomic": "^2.1.2",
+    "rollup": "^2.45.1",
+    "rollup-plugin-atomic": "^2.3.0",
     "shx": "^0.3.3",
-    "typescript": "^4.2.3"
+    "typescript": "^4.2.4"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,26 +1,25 @@
 lockfileVersion: 5.3
 
 specifiers:
-  babel-preset-atomic: ^3.0.3
   bindings: ~1.5.0
   coffeescript: ^2.5.1
   cross-env: ^7.0.3
   deep-equal: ^2.0.5
-  eslint: ^7.23.0
-  eslint-config-atomic: ^1.12.4
+  eslint: ^7.24.0
+  eslint-config-atomic: ^1.14.0
   fuzzaldrin-plus: ^0.6.0
   growl: '>=1.10.5'
   jasmine: ^3.7.0
   jasmine-node: ^3.0.0
   node-addon-api: ~3.1.0
   node-gyp-build: ^4.2.3
-  npm-check-updates: 11.3.0
+  npm-check-updates: 11.4.1
   prebuildify: ^4.1.2
   prettier-config-atomic: ^2.0.1
-  rollup: ^2.43.1
-  rollup-plugin-atomic: ^2.1.2
+  rollup: ^2.45.1
+  rollup-plugin-atomic: ^2.3.0
   shx: ^0.3.3
-  typescript: ^4.2.3
+  typescript: ^4.2.4
 
 dependencies:
   bindings: 1.5.0
@@ -28,23 +27,22 @@ dependencies:
   node-gyp-build: 4.2.3
 
 devDependencies:
-  babel-preset-atomic: 3.0.3
   coffeescript: 2.5.1
   cross-env: 7.0.3
   deep-equal: 2.0.5
-  eslint: 7.23.0
-  eslint-config-atomic: 1.12.4_eslint@7.23.0
+  eslint: 7.24.0
+  eslint-config-atomic: 1.14.0
   fuzzaldrin-plus: 0.6.0
   growl: 1.10.5
   jasmine: 3.7.0
   jasmine-node: 3.0.0
-  npm-check-updates: 11.3.0
+  npm-check-updates: 11.4.1
   prebuildify: 4.1.2
   prettier-config-atomic: 2.0.1
-  rollup: 2.43.1
-  rollup-plugin-atomic: 2.1.2_rollup@2.43.1
+  rollup: 2.45.1
+  rollup-plugin-atomic: 2.3.0
   shx: 0.3.3
-  typescript: 4.2.3
+  typescript: 4.2.4
 
 packages:
 
@@ -60,8 +58,8 @@ packages:
       '@babel/highlight': 7.13.10
     dev: true
 
-  /@babel/compat-data/7.13.11:
-    resolution: {integrity: sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg==}
+  /@babel/compat-data/7.13.15:
+    resolution: {integrity: sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==}
     dev: true
 
   /@babel/core/7.13.10:
@@ -91,33 +89,9 @@ packages:
   /@babel/generator/7.13.9:
     resolution: {integrity: sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==}
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.12
       jsesc: 2.5.2
       source-map: 0.5.7
-    dev: true
-
-  /@babel/helper-annotate-as-pure/7.12.13:
-    resolution: {integrity: sha512-7YXfX5wQ5aYM/BOlbSccHDbuXXFPxeoUmfWtz8le2yTkTZc+BxsiEnENFoi2SlmA8ewDkG2LgIMIVzzn2h8kfw==}
-    dependencies:
-      '@babel/types': 7.13.0
-    dev: true
-
-  /@babel/helper-builder-binary-assignment-operator-visitor/7.12.13:
-    resolution: {integrity: sha512-CZOv9tGphhDRlVjVkAgm8Nhklm9RzSmWpX2my+t7Ua/KT616pEzXsQCjinzvkRvHWJ9itO4f296efroX23XCMA==}
-    dependencies:
-      '@babel/helper-explode-assignable-expression': 7.13.0
-      '@babel/types': 7.13.0
-    dev: true
-
-  /@babel/helper-compilation-targets/7.13.10:
-    resolution: {integrity: sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.13.11
-      '@babel/helper-validator-option': 7.12.17
-      browserslist: 4.16.0
-      semver: 6.3.0
     dev: true
 
   /@babel/helper-compilation-targets/7.13.10_@babel+core@7.13.10:
@@ -125,57 +99,11 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.13.11
+      '@babel/compat-data': 7.13.15
       '@babel/core': 7.13.10
       '@babel/helper-validator-option': 7.12.17
-      browserslist: 4.16.0
+      browserslist: 4.16.3
       semver: 6.3.0
-    dev: true
-
-  /@babel/helper-create-class-features-plugin/7.13.11:
-    resolution: {integrity: sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-member-expression-to-functions': 7.13.0
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/helper-replace-supers': 7.13.0
-      '@babel/helper-split-export-declaration': 7.12.13
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/helper-create-regexp-features-plugin/7.12.17:
-    resolution: {integrity: sha512-p2VGmBu9oefLZ2nQpgnEnG0ZlRPvL8gAGvPUMQwUdaE8k49rOMuZpOwdQoy5qJf6K8jL3bcAMhVUlHAjIgJHUg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.12.13
-      regexpu-core: 4.7.1
-    dev: true
-
-  /@babel/helper-define-polyfill-provider/0.1.5:
-    resolution: {integrity: sha512-nXuzCSwlJ/WKr8qxzW816gwyT6VZgiJG17zR40fou70yfAcqjoNyTLl/DQ+FExw5Hx5KNqshmN8Ldl/r2N7cTg==}
-    peerDependencies:
-      '@babel/core': ^7.4.0-0
-    dependencies:
-      '@babel/helper-compilation-targets': 7.13.10
-      '@babel/helper-module-imports': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/traverse': 7.13.0
-      debug: 4.3.1
-      lodash.debounce: 4.0.8
-      resolve: 1.19.0
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/helper-explode-assignable-expression/7.13.0:
-    resolution: {integrity: sha512-qS0peLTDP8kOisG1blKbaoBg/o9OSa1qoumMjTK5pM+KDTtpxpsiubnCGP34vK8BXGcb2M9eigwgvoJryrzwWA==}
-    dependencies:
-      '@babel/types': 7.13.0
     dev: true
 
   /@babel/helper-function-name/7.12.13:
@@ -183,28 +111,13 @@ packages:
     dependencies:
       '@babel/helper-get-function-arity': 7.12.13
       '@babel/template': 7.12.13
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.12
     dev: true
 
   /@babel/helper-get-function-arity/7.12.13:
     resolution: {integrity: sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==}
     dependencies:
-      '@babel/types': 7.13.0
-    dev: true
-
-  /@babel/helper-hoist-variables/7.13.0:
-    resolution: {integrity: sha512-0kBzvXiIKfsCA0y6cFEIJf4OdzfpRuNk4+YTeHZpGGc666SATFKTz6sRncwFnQk7/ugJ4dSrCj6iJuvW4Qwr2g==}
-    dependencies:
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/helper-member-expression-to-functions/7.13.0:
-    resolution: {integrity: sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==}
-    dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.12
     dev: true
 
   /@babel/helper-member-expression-to-functions/7.13.12:
@@ -213,32 +126,10 @@ packages:
       '@babel/types': 7.13.12
     dev: true
 
-  /@babel/helper-module-imports/7.12.13:
-    resolution: {integrity: sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==}
-    dependencies:
-      '@babel/types': 7.13.0
-    dev: true
-
   /@babel/helper-module-imports/7.13.12:
     resolution: {integrity: sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==}
     dependencies:
       '@babel/types': 7.13.12
-    dev: true
-
-  /@babel/helper-module-transforms/7.13.0:
-    resolution: {integrity: sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==}
-    dependencies:
-      '@babel/helper-module-imports': 7.12.13
-      '@babel/helper-replace-supers': 7.13.0
-      '@babel/helper-simple-access': 7.12.13
-      '@babel/helper-split-export-declaration': 7.12.13
-      '@babel/helper-validator-identifier': 7.12.11
-      '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
-      lodash: 4.17.21
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/helper-module-transforms/7.13.12:
@@ -259,32 +150,7 @@ packages:
   /@babel/helper-optimise-call-expression/7.12.13:
     resolution: {integrity: sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==}
     dependencies:
-      '@babel/types': 7.13.0
-    dev: true
-
-  /@babel/helper-plugin-utils/7.13.0:
-    resolution: {integrity: sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==}
-    dev: true
-
-  /@babel/helper-remap-async-to-generator/7.13.0:
-    resolution: {integrity: sha512-pUQpFBE9JvC9lrQbpX0TmeNIy5s7GnZjna2lhhcHC7DzgBs6fWn722Y5cfwgrtrqc7NAJwMvOa0mKhq6XaE4jg==}
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-wrap-function': 7.13.0
-      '@babel/types': 7.13.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/helper-replace-supers/7.13.0:
-    resolution: {integrity: sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==}
-    dependencies:
-      '@babel/helper-member-expression-to-functions': 7.13.0
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/types': 7.13.12
     dev: true
 
   /@babel/helper-replace-supers/7.13.12:
@@ -298,28 +164,16 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-simple-access/7.12.13:
-    resolution: {integrity: sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==}
-    dependencies:
-      '@babel/types': 7.13.0
-    dev: true
-
   /@babel/helper-simple-access/7.13.12:
     resolution: {integrity: sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==}
     dependencies:
       '@babel/types': 7.13.12
     dev: true
 
-  /@babel/helper-skip-transparent-expression-wrappers/7.12.1:
-    resolution: {integrity: sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==}
-    dependencies:
-      '@babel/types': 7.13.0
-    dev: true
-
   /@babel/helper-split-export-declaration/7.12.13:
     resolution: {integrity: sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==}
     dependencies:
-      '@babel/types': 7.13.0
+      '@babel/types': 7.13.12
     dev: true
 
   /@babel/helper-validator-identifier/7.12.11:
@@ -328,17 +182,6 @@ packages:
 
   /@babel/helper-validator-option/7.12.17:
     resolution: {integrity: sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==}
-    dev: true
-
-  /@babel/helper-wrap-function/7.13.0:
-    resolution: {integrity: sha512-1UX9F7K3BS42fI6qd2A4BjKzgGjToscyZTdp1DjknHLCIvpgne6918io+aL5LXFcER/8QWiwpoY902pVEqgTXA==}
-    dependencies:
-      '@babel/helper-function-name': 7.12.13
-      '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.0
-      '@babel/types': 7.13.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/helpers/7.13.10:
@@ -359,852 +202,16 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@babel/parser/7.13.11:
-    resolution: {integrity: sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dev: true
-
   /@babel/parser/7.13.12:
     resolution: {integrity: sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dev: true
 
-  /@babel/plugin-proposal-async-generator-functions/7.13.8:
-    resolution: {integrity: sha512-rPBnhj+WgoSmgq+4gQUtXx/vOcU+UYtjy1AA/aeD61Hwj410fwYyqfUcRP3lR8ucgliVJL/G7sXcNUecC75IXA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-remap-async-to-generator': 7.13.0
-      '@babel/plugin-syntax-async-generators': 7.8.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-proposal-class-properties/7.13.0:
-    resolution: {integrity: sha512-KnTDjFNC1g+45ka0myZNvSBFLhNCLN+GeGYLDEA8Oq7MZ6yMgfLoIRh86GRT0FjtJhZw8JyUskP9uvj5pHM9Zg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-create-class-features-plugin': 7.13.11
-      '@babel/helper-plugin-utils': 7.13.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-proposal-decorators/7.13.5:
-    resolution: {integrity: sha512-i0GDfVNuoapwiheevUOuSW67mInqJ8qw7uWfpjNVeHMn143kXblEy/bmL9AdZ/0yf/4BMQeWXezK0tQIvNPqag==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-create-class-features-plugin': 7.13.11
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-decorators': 7.12.13
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-proposal-do-expressions/7.12.13:
-    resolution: {integrity: sha512-NXmNoFKXQ+BXWU474n+cT4C5I/OI3rMiZCKJ/PtA/7AGMjGreXrt+YfoGmgm7Wimz/qumrycHNvg/fr4q2uv0w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-do-expressions': 7.12.13
-    dev: true
-
-  /@babel/plugin-proposal-dynamic-import/7.13.8:
-    resolution: {integrity: sha512-ONWKj0H6+wIRCkZi9zSbZtE/r73uOhMVHh256ys0UzfM7I3d4n+spZNWjOnJv2gzopumP2Wxi186vI8N0Y2JyQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-dynamic-import': 7.8.3
-    dev: true
-
-  /@babel/plugin-proposal-export-default-from/7.12.13:
-    resolution: {integrity: sha512-idIsBT+DGXdOHL82U+8bwX4goHm/z10g8sGGrQroh+HCRcm7mDv/luaGdWJQMTuCX2FsdXS7X0Nyyzp4znAPJA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-export-default-from': 7.12.13
-    dev: true
-
-  /@babel/plugin-proposal-export-namespace-from/7.12.13:
-    resolution: {integrity: sha512-INAgtFo4OnLN3Y/j0VwAgw3HDXcDtX+C/erMvWzuV9v71r7urb6iyMXu7eM9IgLr1ElLlOkaHjJ0SbCmdOQ3Iw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3
-    dev: true
-
-  /@babel/plugin-proposal-function-bind/7.12.13:
-    resolution: {integrity: sha512-HdFUUOUhB5WuNug+rfhcRvjqjjtKdJlWr6kgIezpbh9xiIEza/pPWw+bJeH2GdGeUyNqhRIYeFKt0M3/xXWp1w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-function-bind': 7.12.13
-    dev: true
-
-  /@babel/plugin-proposal-function-sent/7.12.13:
-    resolution: {integrity: sha512-nw5dSsy0+o+WBE372ooERkkZmFv2KJcujzTB5SdhQPKIElVA1pa7hclD23Vzl4VlcoJsC7KCCXpww2qAkbrrKA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-wrap-function': 7.13.0
-      '@babel/plugin-syntax-function-sent': 7.12.13
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-proposal-json-strings/7.13.8:
-    resolution: {integrity: sha512-w4zOPKUFPX1mgvTmL/fcEqy34hrQ1CRcGxdphBc6snDnnqJ47EZDIyop6IwXzAC8G916hsIuXB2ZMBCExC5k7Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-json-strings': 7.8.3
-    dev: true
-
-  /@babel/plugin-proposal-logical-assignment-operators/7.13.8:
-    resolution: {integrity: sha512-aul6znYB4N4HGweImqKn59Su9RS8lbUIqxtXTOcAGtNIDczoEFv+l1EhmX8rUBp3G1jMjKJm8m0jXVp63ZpS4A==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4
-    dev: true
-
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.13.8:
-    resolution: {integrity: sha512-iePlDPBn//UhxExyS9KyeYU7RM9WScAG+D3Hhno0PLJebAEpDZMocbDe64eqynhNAnwz/vZoL/q/QB2T1OH39A==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3
-    dev: true
-
-  /@babel/plugin-proposal-numeric-separator/7.12.13:
-    resolution: {integrity: sha512-O1jFia9R8BUCl3ZGB7eitaAPu62TXJRHn7rh+ojNERCFyqRwJMTmhz+tJ+k0CwI6CLjX/ee4qW74FSqlq9I35w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-numeric-separator': 7.10.4
-    dev: true
-
-  /@babel/plugin-proposal-object-rest-spread/7.13.8:
-    resolution: {integrity: sha512-DhB2EuB1Ih7S3/IRX5AFVgZ16k3EzfRbq97CxAVI1KSYcW+lexV8VZb7G7L8zuPVSdQMRn0kiBpf/Yzu9ZKH0g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.13.11
-      '@babel/helper-compilation-targets': 7.13.10
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3
-      '@babel/plugin-transform-parameters': 7.13.0
-    dev: true
-
-  /@babel/plugin-proposal-optional-catch-binding/7.13.8:
-    resolution: {integrity: sha512-0wS/4DUF1CuTmGo+NiaHfHcVSeSLj5S3e6RivPTg/2k3wOv3jO35tZ6/ZWsQhQMvdgI7CwphjQa/ccarLymHVA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3
-    dev: true
-
-  /@babel/plugin-proposal-optional-chaining/7.13.8:
-    resolution: {integrity: sha512-hpbBwbTgd7Cz1QryvwJZRo1U0k1q8uyBmeXOSQUjdg/A2TASkhR/rz7AyqZ/kS8kbpsNA80rOYbxySBJAqmhhQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
-      '@babel/plugin-syntax-optional-chaining': 7.8.3
-    dev: true
-
-  /@babel/plugin-proposal-pipeline-operator/7.12.13:
-    resolution: {integrity: sha512-p6ypYNG6oKPHO73jPjyBVrZMcc2bWWn8ByusDzStzlPmWNElcErf+pZGB6Lt5f23T9LFFTB7rqOr8BQMc1nSiQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-pipeline-operator': 7.12.13
-    dev: true
-
-  /@babel/plugin-proposal-private-methods/7.13.0:
-    resolution: {integrity: sha512-MXyyKQd9inhx1kDYPkFRVOBXQ20ES8Pto3T7UZ92xj2mY0EVD8oAVzeyYuVfy/mxAdTSIayOvg+aVzcHV2bn6Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-create-class-features-plugin': 7.13.11
-      '@babel/helper-plugin-utils': 7.13.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-proposal-throw-expressions/7.12.13:
-    resolution: {integrity: sha512-zhItTJGy2xLYneBdOk9CeyuEXWJt9J+pwTEIDl+A/VKMCq6E9ij3l1RRuTYBwtktTO9bCcIfA4/+d0HibVWSEA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-throw-expressions': 7.12.13
-    dev: true
-
-  /@babel/plugin-proposal-unicode-property-regex/7.12.13:
-    resolution: {integrity: sha512-XyJmZidNfofEkqFV5VC/bLabGmO5QzenPO/YOfGuEbgU+2sSwMmio3YLb4WtBgcmmdwZHyVyv8on77IUjQ5Gvg==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.12.17
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-async-generators/7.8.4:
-    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-class-properties/7.12.13:
-    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-decorators/7.12.13:
-    resolution: {integrity: sha512-Rw6aIXGuqDLr6/LoBBYE57nKOzQpz/aDkKlMqEwH+Vp0MXbG6H/TfRjaY343LKxzAKAMXIHsQ8JzaZKuDZ9MwA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-do-expressions/7.12.13:
-    resolution: {integrity: sha512-xm52bNA0O8QPH4rBXXJ/VLaQ6UGocUS3/fbgZO5z+KDUU7y8iFy8cnIwuRS/NNGjs18sOquzJfH0EasQv+F1oQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-dynamic-import/7.8.3:
-    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-export-default-from/7.12.13:
-    resolution: {integrity: sha512-gVry0zqoums0hA+EniCYK3gABhjYSLX1dVuwYpPw9DrLNA4/GovXySHVg4FGRsZht09ON/5C2NVx3keq+qqVGQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-export-namespace-from/7.8.3:
-    resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-flow/7.12.13:
-    resolution: {integrity: sha512-J/RYxnlSLXZLVR7wTRsozxKT8qbsx1mNKJzXEEjQ0Kjx1ZACcyHgbanNWNCFtc36IzuWhYWPpvJFFoexoOWFmA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-function-bind/7.12.13:
-    resolution: {integrity: sha512-8tkZMgbO5s/WkVnl04rBvULapZeXOHkaEW+w7oSzmEKwD6hDCtaAKouhgpoMa3uo8zC1HFpjlVh85PUVqvAxHw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-function-sent/7.12.13:
-    resolution: {integrity: sha512-Uv9lAv+/vX8hmvC2rTUvywJacR517eRqTKfLZrtLAoMGUjfQSZ0nPEFJWmfJs1H54zBaIj15ATfUnkheZnSK9w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-import-meta/7.10.4:
-    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-json-strings/7.8.3:
-    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-jsx/7.12.13:
-    resolution: {integrity: sha512-d4HM23Q1K7oq/SLNmG6mRt85l2csmQ0cHRaxRXjKW0YFdEXqlZ5kzFQKH5Uc3rDJECgu+yCRgPkG04Mm98R/1g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4:
-    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3:
-    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-numeric-separator/7.10.4:
-    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-object-rest-spread/7.8.3:
-    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3:
-    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-optional-chaining/7.8.3:
-    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-pipeline-operator/7.12.13:
-    resolution: {integrity: sha512-IHs5FTRPJv7M7K0IurpuCTU1ILnhAXDi+YW8dIddJywIDWEYAaV90pSk1RnHRAyExn8szPER1SaraZdZLxKOGw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-throw-expressions/7.12.13:
-    resolution: {integrity: sha512-vbpx/IxHR3qqWEfYeiVLq4+RFj2F4GjsMzoXEx/YU/pgmTA6o7T92DQHWIeetg7msKQFnyG1PwmPLWMlAn+Fmg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-syntax-top-level-await/7.12.13:
-    resolution: {integrity: sha512-A81F9pDwyS7yM//KwbCSDqy3Uj4NMIurtplxphWxoYtNPov7cJsDkAFNNyVlIZ3jwGycVsurZ+LtOA8gZ376iQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-arrow-functions/7.13.0:
-    resolution: {integrity: sha512-96lgJagobeVmazXFaDrbmCLQxBysKu7U6Do3mLsx27gf5Dk85ezysrs2BZUpXD703U/Su1xTBDxxar2oa4jAGg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-async-to-generator/7.13.0:
-    resolution: {integrity: sha512-3j6E004Dx0K3eGmhxVJxwwI89CTJrce7lg3UrtFuDAVQ/2+SJ/h/aSFOeE6/n0WB1GsOffsJp6MnPQNQ8nmwhg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-module-imports': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-remap-async-to-generator': 7.13.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-block-scoped-functions/7.12.13:
-    resolution: {integrity: sha512-zNyFqbc3kI/fVpqwfqkg6RvBgFpC4J18aKKMmv7KdQ/1GgREapSJAykLMVNwfRGO3BtHj3YQZl8kxCXPcVMVeg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-block-scoping/7.12.13:
-    resolution: {integrity: sha512-Pxwe0iqWJX4fOOM2kEZeUuAxHMWb9nK+9oh5d11bsLoB0xMg+mkDpt0eYuDZB7ETrY9bbcVlKUGTOGWy7BHsMQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-classes/7.13.0:
-    resolution: {integrity: sha512-9BtHCPUARyVH1oXGcSJD3YpsqRLROJx5ZNP6tN5vnk17N0SVf9WCtf8Nuh1CFmgByKKAIMstitKduoCmsaDK5g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-optimise-call-expression': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-replace-supers': 7.13.0
-      '@babel/helper-split-export-declaration': 7.12.13
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-computed-properties/7.13.0:
-    resolution: {integrity: sha512-RRqTYTeZkZAz8WbieLTvKUEUxZlUTdmL5KGMyZj7FnMfLNKV4+r5549aORG/mgojRmFlQMJDUupwAMiF2Q7OUg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-destructuring/7.13.0:
-    resolution: {integrity: sha512-zym5em7tePoNT9s964c0/KU3JPPnuq7VhIxPRefJ4/s82cD+q1mgKfuGRDMCPL0HTyKz4dISuQlCusfgCJ86HA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-dotall-regex/7.12.13:
-    resolution: {integrity: sha512-foDrozE65ZFdUC2OfgeOCrEPTxdB3yjqxpXh8CH+ipd9CHd4s/iq81kcUpyH8ACGNEPdFqbtzfgzbT/ZGlbDeQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.12.17
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-duplicate-keys/7.12.13:
-    resolution: {integrity: sha512-NfADJiiHdhLBW3pulJlJI2NB0t4cci4WTZ8FtdIuNc2+8pslXdPtRRAEWqUY+m9kNOk2eRYbTAOipAxlrOcwwQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-exponentiation-operator/7.12.13:
-    resolution: {integrity: sha512-fbUelkM1apvqez/yYx1/oICVnGo2KM5s63mhGylrmXUxK/IAXSIf87QIxVfZldWf4QsOafY6vV3bX8aMHSvNrA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-flow-strip-types/7.13.0:
-    resolution: {integrity: sha512-EXAGFMJgSX8gxWD7PZtW/P6M+z74jpx3wm/+9pn+c2dOawPpBkUX7BrfyPvo6ZpXbgRIEuwgwDb/MGlKvu2pOg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-flow': 7.12.13
-    dev: true
-
-  /@babel/plugin-transform-for-of/7.13.0:
-    resolution: {integrity: sha512-IHKT00mwUVYE0zzbkDgNRP6SRzvfGCYsOxIRz8KsiaaHCcT9BWIkO+H9QRJseHBLOGBZkHUdHiqj6r0POsdytg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-function-name/7.12.13:
-    resolution: {integrity: sha512-6K7gZycG0cmIwwF7uMK/ZqeCikCGVBdyP2J5SKNCXO5EOHcqi+z7Jwf8AmyDNcBgxET8DrEtCt/mPKPyAzXyqQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-literals/7.12.13:
-    resolution: {integrity: sha512-FW+WPjSR7hiUxMcKqyNjP05tQ2kmBCdpEpZHY1ARm96tGQCCBvXKnpjILtDplUnJ/eHZ0lALLM+d2lMFSpYJrQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-member-expression-literals/7.12.13:
-    resolution: {integrity: sha512-kxLkOsg8yir4YeEPHLuO2tXP9R/gTjpuTOjshqSpELUN3ZAg2jfDnKUvzzJxObun38sw3wm4Uu69sX/zA7iRvg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-modules-amd/7.13.0:
-    resolution: {integrity: sha512-EKy/E2NHhY/6Vw5d1k3rgoobftcNUmp9fGjb9XZwQLtTctsRBOTRO7RHHxfIky1ogMN5BxN7p9uMA3SzPfotMQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-module-transforms': 7.13.0
-      '@babel/helper-plugin-utils': 7.13.0
-      babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-modules-commonjs/7.13.8:
-    resolution: {integrity: sha512-9QiOx4MEGglfYZ4XOnU79OHr6vIWUakIj9b4mioN8eQIoEh+pf5p/zEB36JpDFWA12nNMiRf7bfoRvl9Rn79Bw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-module-transforms': 7.13.0
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-simple-access': 7.12.13
-      babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-modules-systemjs/7.13.8:
-    resolution: {integrity: sha512-hwqctPYjhM6cWvVIlOIe27jCIBgHCsdH2xCJVAYQm7V5yTMoilbVMi9f6wKg0rpQAOn6ZG4AOyvCqFF/hUh6+A==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-hoist-variables': 7.13.0
-      '@babel/helper-module-transforms': 7.13.0
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-validator-identifier': 7.12.11
-      babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-modules-umd/7.13.0:
-    resolution: {integrity: sha512-D/ILzAh6uyvkWjKKyFE/W0FzWwasv6vPTSqPcjxFqn6QpX3u8DjRVliq4F2BamO2Wee/om06Vyy+vPkNrd4wxw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-module-transforms': 7.13.0
-      '@babel/helper-plugin-utils': 7.13.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-named-capturing-groups-regex/7.12.13:
-    resolution: {integrity: sha512-Xsm8P2hr5hAxyYblrfACXpQKdQbx4m2df9/ZZSQ8MAhsadw06+jW7s9zsSw6he+mJZXRlVMyEnVktJo4zjk1WA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.12.17
-    dev: true
-
-  /@babel/plugin-transform-new-target/7.12.13:
-    resolution: {integrity: sha512-/KY2hbLxrG5GTQ9zzZSc3xWiOy379pIETEhbtzwZcw9rvuaVV4Fqy7BYGYOWZnaoXIQYbbJ0ziXLa/sKcGCYEQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-object-super/7.12.13:
-    resolution: {integrity: sha512-JzYIcj3XtYspZDV8j9ulnoMPZZnF/Cj0LUxPOjR89BdBVx+zYJI9MdMIlUZjbXDX+6YVeS6I3e8op+qQ3BYBoQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-replace-supers': 7.13.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-parameters/7.13.0:
-    resolution: {integrity: sha512-Jt8k/h/mIwE2JFEOb3lURoY5C85ETcYPnbuAJ96zRBzh1XHtQZfs62ChZ6EP22QlC8c7Xqr9q+e1SU5qttwwjw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-property-literals/7.12.13:
-    resolution: {integrity: sha512-nqVigwVan+lR+g8Fj8Exl0UQX2kymtjcWfMOYM1vTYEKujeyv2SkMgazf2qNcK7l4SDiKyTA/nHCPqL4e2zo1A==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-react-display-name/7.12.13:
-    resolution: {integrity: sha512-MprESJzI9O5VnJZrL7gg1MpdqmiFcUv41Jc7SahxYsNP2kDkFqClxxTZq+1Qv4AFCamm+GXMRDQINNn+qrxmiA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-react-jsx-development/7.12.17:
-    resolution: {integrity: sha512-BPjYV86SVuOaudFhsJR1zjgxxOhJDt6JHNoD48DxWEIxUCAMjV1ys6DYw4SDYZh0b1QsS2vfIA9t/ZsQGsDOUQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/plugin-transform-react-jsx': 7.12.17
-    dev: true
-
-  /@babel/plugin-transform-react-jsx/7.12.17:
-    resolution: {integrity: sha512-mwaVNcXV+l6qJOuRhpdTEj8sT/Z0owAVWf9QujTZ0d2ye9X/K+MTOTSizcgKOj18PGnTc/7g1I4+cIUjsKhBcw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-module-imports': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-syntax-jsx': 7.12.13
-      '@babel/types': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-react-pure-annotations/7.12.1:
-    resolution: {integrity: sha512-RqeaHiwZtphSIUZ5I85PEH19LOSzxfuEazoY7/pWASCAIBuATQzpSVD+eT6MebeeZT2F4eSL0u4vw6n4Nm0Mjg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.12.13
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-regenerator/7.12.13:
-    resolution: {integrity: sha512-lxb2ZAvSLyJ2PEe47hoGWPmW22v7CtSl9jW8mingV4H2sEX/JOcrAj2nPuGWi56ERUm2bUpjKzONAuT6HCn2EA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      regenerator-transform: 0.14.5
-    dev: true
-
-  /@babel/plugin-transform-reserved-words/7.12.13:
-    resolution: {integrity: sha512-xhUPzDXxZN1QfiOy/I5tyye+TRz6lA7z6xaT4CLOjPRMVg1ldRf0LHw0TDBpYL4vG78556WuHdyO9oi5UmzZBg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-shorthand-properties/7.12.13:
-    resolution: {integrity: sha512-xpL49pqPnLtf0tVluuqvzWIgLEhuPpZzvs2yabUHSKRNlN7ScYU7aMlmavOeyXJZKgZKQRBlh8rHbKiJDraTSw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-spread/7.13.0:
-    resolution: {integrity: sha512-V6vkiXijjzYeFmQTr3dBxPtZYLPcUfY34DebOU27jIl2M/Y8Egm52Hw82CSjjPqd54GTlJs5x+CR7HeNr24ckg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
-    dev: true
-
-  /@babel/plugin-transform-sticky-regex/7.12.13:
-    resolution: {integrity: sha512-Jc3JSaaWT8+fr7GRvQP02fKDsYk4K/lYwWq38r/UGfaxo89ajud321NH28KRQ7xy1Ybc0VUE5Pz8psjNNDUglg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-template-literals/7.13.0:
-    resolution: {integrity: sha512-d67umW6nlfmr1iehCcBv69eSUSySk1EsIS8aTDX4Xo9qajAh6mYtcl4kJrBkGXuxZPEgVr7RVfAvNW6YQkd4Mw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-typeof-symbol/7.12.13:
-    resolution: {integrity: sha512-eKv/LmUJpMnu4npgfvs3LiHhJua5fo/CysENxa45YCQXZwKnGCQKAg87bvoqSW1fFT+HA32l03Qxsm8ouTY3ZQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-unicode-escapes/7.12.13:
-    resolution: {integrity: sha512-0bHEkdwJ/sN/ikBHfSmOXPypN/beiGqjo+o4/5K+vxEFNPRPdImhviPakMKG4x96l85emoa0Z6cDflsdBusZbw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/plugin-transform-unicode-regex/7.12.13:
-    resolution: {integrity: sha512-mDRzSNY7/zopwisPZ5kM9XKCfhchqIYwAKRERtEnhYscZB79VRekuRSoYbN0+KVe3y8+q1h6A4svXtP7N+UoCA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.12.17
-      '@babel/helper-plugin-utils': 7.13.0
-    dev: true
-
-  /@babel/preset-env/7.13.10:
-    resolution: {integrity: sha512-nOsTScuoRghRtUsRr/c69d042ysfPHcu+KOB4A9aAO9eJYqrkat+LF8G1yp1HD18QiwixT2CisZTr/0b3YZPXQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.13.11
-      '@babel/helper-compilation-targets': 7.13.10
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/helper-validator-option': 7.12.17
-      '@babel/plugin-proposal-async-generator-functions': 7.13.8
-      '@babel/plugin-proposal-class-properties': 7.13.0
-      '@babel/plugin-proposal-dynamic-import': 7.13.8
-      '@babel/plugin-proposal-export-namespace-from': 7.12.13
-      '@babel/plugin-proposal-json-strings': 7.13.8
-      '@babel/plugin-proposal-logical-assignment-operators': 7.13.8
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.13.8
-      '@babel/plugin-proposal-numeric-separator': 7.12.13
-      '@babel/plugin-proposal-object-rest-spread': 7.13.8
-      '@babel/plugin-proposal-optional-catch-binding': 7.13.8
-      '@babel/plugin-proposal-optional-chaining': 7.13.8
-      '@babel/plugin-proposal-private-methods': 7.13.0
-      '@babel/plugin-proposal-unicode-property-regex': 7.12.13
-      '@babel/plugin-syntax-async-generators': 7.8.4
-      '@babel/plugin-syntax-class-properties': 7.12.13
-      '@babel/plugin-syntax-dynamic-import': 7.8.3
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3
-      '@babel/plugin-syntax-json-strings': 7.8.3
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3
-      '@babel/plugin-syntax-numeric-separator': 7.10.4
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3
-      '@babel/plugin-syntax-optional-chaining': 7.8.3
-      '@babel/plugin-syntax-top-level-await': 7.12.13
-      '@babel/plugin-transform-arrow-functions': 7.13.0
-      '@babel/plugin-transform-async-to-generator': 7.13.0
-      '@babel/plugin-transform-block-scoped-functions': 7.12.13
-      '@babel/plugin-transform-block-scoping': 7.12.13
-      '@babel/plugin-transform-classes': 7.13.0
-      '@babel/plugin-transform-computed-properties': 7.13.0
-      '@babel/plugin-transform-destructuring': 7.13.0
-      '@babel/plugin-transform-dotall-regex': 7.12.13
-      '@babel/plugin-transform-duplicate-keys': 7.12.13
-      '@babel/plugin-transform-exponentiation-operator': 7.12.13
-      '@babel/plugin-transform-for-of': 7.13.0
-      '@babel/plugin-transform-function-name': 7.12.13
-      '@babel/plugin-transform-literals': 7.12.13
-      '@babel/plugin-transform-member-expression-literals': 7.12.13
-      '@babel/plugin-transform-modules-amd': 7.13.0
-      '@babel/plugin-transform-modules-commonjs': 7.13.8
-      '@babel/plugin-transform-modules-systemjs': 7.13.8
-      '@babel/plugin-transform-modules-umd': 7.13.0
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.12.13
-      '@babel/plugin-transform-new-target': 7.12.13
-      '@babel/plugin-transform-object-super': 7.12.13
-      '@babel/plugin-transform-parameters': 7.13.0
-      '@babel/plugin-transform-property-literals': 7.12.13
-      '@babel/plugin-transform-regenerator': 7.12.13
-      '@babel/plugin-transform-reserved-words': 7.12.13
-      '@babel/plugin-transform-shorthand-properties': 7.12.13
-      '@babel/plugin-transform-spread': 7.13.0
-      '@babel/plugin-transform-sticky-regex': 7.12.13
-      '@babel/plugin-transform-template-literals': 7.13.0
-      '@babel/plugin-transform-typeof-symbol': 7.12.13
-      '@babel/plugin-transform-unicode-escapes': 7.12.13
-      '@babel/plugin-transform-unicode-regex': 7.12.13
-      '@babel/preset-modules': 0.1.4
-      '@babel/types': 7.13.0
-      babel-plugin-polyfill-corejs2: 0.1.10
-      babel-plugin-polyfill-corejs3: 0.1.7
-      babel-plugin-polyfill-regenerator: 0.1.6
-      core-js-compat: 3.9.1
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/preset-flow/7.12.13:
-    resolution: {integrity: sha512-gcEjiwcGHa3bo9idURBp5fmJPcyFPOszPQjztXrOjUE2wWVqc6fIVJPgWPIQksaQ5XZ2HWiRsf2s1fRGVjUtVw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-transform-flow-strip-types': 7.13.0
-    dev: true
-
-  /@babel/preset-modules/0.1.4:
-    resolution: {integrity: sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-proposal-unicode-property-regex': 7.12.13
-      '@babel/plugin-transform-dotall-regex': 7.12.13
-      '@babel/types': 7.13.0
-      esutils: 2.0.3
-    dev: true
-
-  /@babel/preset-react/7.12.13:
-    resolution: {integrity: sha512-TYM0V9z6Abb6dj1K7i5NrEhA13oS5ujUYQYDfqIBXYHOc2c2VkFgc+q9kyssIyUfy4/hEwqrgSlJ/Qgv8zJLsA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.13.0
-      '@babel/plugin-transform-react-display-name': 7.12.13
-      '@babel/plugin-transform-react-jsx': 7.12.17
-      '@babel/plugin-transform-react-jsx-development': 7.12.17
-      '@babel/plugin-transform-react-pure-annotations': 7.12.1
-    dev: true
-
   /@babel/runtime-corejs3/7.13.10:
     resolution: {integrity: sha512-x/XYVQ1h684pp1mJwOV4CyvqZXqbc8CMsMGUnAbuc82ZCdv1U63w5RSUzgDSXQHG5Rps/kiksH6g2D5BuaKyXg==}
     dependencies:
       core-js-pure: 3.9.1
-      regenerator-runtime: 0.13.7
-    dev: true
-
-  /@babel/runtime/7.12.5:
-    resolution: {integrity: sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==}
-    dependencies:
       regenerator-runtime: 0.13.7
     dev: true
 
@@ -1229,21 +236,13 @@ packages:
       '@babel/generator': 7.13.9
       '@babel/helper-function-name': 7.12.13
       '@babel/helper-split-export-declaration': 7.12.13
-      '@babel/parser': 7.13.11
-      '@babel/types': 7.13.0
+      '@babel/parser': 7.13.12
+      '@babel/types': 7.13.12
       debug: 4.3.1
       globals: 11.12.0
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@babel/types/7.13.0:
-    resolution: {integrity: sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.12.11
-      lodash: 4.17.21
-      to-fast-properties: 2.0.0
     dev: true
 
   /@babel/types/7.13.12:
@@ -1305,7 +304,7 @@ packages:
       npm-pick-manifest: 6.1.0
       promise-inflight: 1.0.1
       promise-retry: 1.1.1
-      semver: 7.3.4
+      semver: 7.3.5
       unique-filename: 1.1.1
       which: 2.0.2
     dev: true
@@ -1346,7 +345,7 @@ packages:
       read-package-json-fast: 2.0.2
     dev: true
 
-  /@rollup/plugin-babel/5.3.0_b71b3f5cf92718a15610ac8d891f611a:
+  /@rollup/plugin-babel/5.3.0_08db584e23334d2e829dd80bbfffb699:
     resolution: {integrity: sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -1359,61 +358,61 @@ packages:
     dependencies:
       '@babel/core': 7.13.10
       '@babel/helper-module-imports': 7.13.12
-      '@rollup/pluginutils': 3.1.0_rollup@2.43.1
-      rollup: 2.43.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.45.1
+      rollup: 2.45.1
     dev: true
 
-  /@rollup/plugin-commonjs/18.0.0_rollup@2.43.1:
+  /@rollup/plugin-commonjs/18.0.0_rollup@2.45.1:
     resolution: {integrity: sha512-fj92shhg8luw7XbA0HowAqz90oo7qtLGwqTKbyZ8pmOyH8ui5e+u0wPEgeHLH3djcVma6gUCUrjY6w5R2o1u6g==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
       rollup: ^2.30.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.43.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.45.1
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 7.1.6
       is-reference: 1.2.1
       magic-string: 0.25.7
       resolve: 1.20.0
-      rollup: 2.43.1
+      rollup: 2.45.1
     dev: true
 
-  /@rollup/plugin-json/4.1.0_rollup@2.43.1:
+  /@rollup/plugin-json/4.1.0_rollup@2.45.1:
     resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.43.1
-      rollup: 2.43.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.45.1
+      rollup: 2.45.1
     dev: true
 
-  /@rollup/plugin-node-resolve/11.2.1_rollup@2.43.1:
+  /@rollup/plugin-node-resolve/11.2.1_rollup@2.45.1:
     resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.43.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.45.1
       '@types/resolve': 1.17.1
       builtin-modules: 3.2.0
       deepmerge: 4.2.2
       is-module: 1.0.0
       resolve: 1.20.0
-      rollup: 2.43.1
+      rollup: 2.45.1
     dev: true
 
-  /@rollup/plugin-replace/2.4.2_rollup@2.43.1:
+  /@rollup/plugin-replace/2.4.2_rollup@2.45.1:
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.43.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.45.1
       magic-string: 0.25.7
-      rollup: 2.43.1
+      rollup: 2.45.1
     dev: true
 
-  /@rollup/plugin-typescript/8.2.1_6677de9b412b48c22c27642d5fb54be4:
+  /@rollup/plugin-typescript/8.2.1_b51314abecd42a5fbdb6553ef5e24827:
     resolution: {integrity: sha512-Qd2E1pleDR4bwyFxqbjt4eJf+wB0UKVMLc7/BAFDGVdAXQMCsD4DUv5/7/ww47BZCYxWtJqe1Lo0KVNswBJlRw==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -1421,23 +420,23 @@ packages:
       tslib: '*'
       typescript: '>=3.7.0'
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.43.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.45.1
       resolve: 1.20.0
-      rollup: 2.43.1
-      tslib: 2.1.0
-      typescript: 4.2.3
+      rollup: 2.45.1
+      tslib: 2.2.0
+      typescript: 4.2.4
     dev: true
 
-  /@rollup/plugin-wasm/5.1.2_rollup@2.43.1:
+  /@rollup/plugin-wasm/5.1.2_rollup@2.45.1:
     resolution: {integrity: sha512-eiOuMHBNY0EGTq3LCebg4IQ6/SOvKjmGetzqKajJWcbDQkrQZvHihZKKnBJYY7NuuvjNqCLdEViYr5aAZms63g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      rollup: 2.43.1
+      rollup: 2.45.1
     dev: true
 
-  /@rollup/pluginutils/3.1.0_rollup@2.43.1:
+  /@rollup/pluginutils/3.1.0_rollup@2.45.1:
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
@@ -1446,10 +445,10 @@ packages:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.2.2
-      rollup: 2.43.1
+      rollup: 2.45.1
     dev: true
 
-  /@rollup/pluginutils/4.1.0_rollup@2.43.1:
+  /@rollup/pluginutils/4.1.0_rollup@2.45.1:
     resolution: {integrity: sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
@@ -1457,7 +456,7 @@ packages:
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.2.2
-      rollup: 2.43.1
+      rollup: 2.45.1
     dev: true
 
   /@sindresorhus/is/0.14.0:
@@ -1503,10 +502,6 @@ packages:
     resolution: {integrity: sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==}
     dev: true
 
-  /@types/parse-json/4.0.0:
-    resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
-    dev: true
-
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
@@ -1517,8 +512,8 @@ packages:
     resolution: {integrity: sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/4.19.0_821acdc8bc493ad1aa2628c9b724d688:
-    resolution: {integrity: sha512-CRQNQ0mC2Pa7VLwKFbrGVTArfdVDdefS+gTw0oC98vSI98IX5A8EVH4BzJ2FOB0YlCmm8Im36Elad/Jgtvveaw==}
+  /@typescript-eslint/eslint-plugin/4.21.0_bb1772e1f887ed78c68f06416685750e:
+    resolution: {integrity: sha512-FPUyCPKZbVGexmbCFI3EQHzCZdy2/5f+jv6k2EDljGdXSRc0cKvbndd2nHZkSLqCNOPk0jB6lGzwIkglXcYVsQ==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^4.0.0
@@ -1528,32 +523,32 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.19.0_eslint@7.23.0+typescript@4.2.3
-      '@typescript-eslint/parser': 4.19.0_eslint@7.23.0+typescript@4.2.3
-      '@typescript-eslint/scope-manager': 4.19.0
+      '@typescript-eslint/experimental-utils': 4.21.0_eslint@7.24.0+typescript@4.2.4
+      '@typescript-eslint/parser': 4.21.0_eslint@7.24.0+typescript@4.2.4
+      '@typescript-eslint/scope-manager': 4.21.0
       debug: 4.3.1
-      eslint: 7.23.0
+      eslint: 7.24.0
       functional-red-black-tree: 1.0.1
       lodash: 4.17.21
       regexpp: 3.1.0
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.2.3
-      typescript: 4.2.3
+      tsutils: 3.21.0_typescript@4.2.4
+      typescript: 4.2.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/4.19.0_eslint@7.23.0+typescript@4.2.3:
-    resolution: {integrity: sha512-9/23F1nnyzbHKuoTqFN1iXwN3bvOm/PRIXSBR3qFAYotK/0LveEOHr5JT1WZSzcD6BESl8kPOG3OoDRKO84bHA==}
+  /@typescript-eslint/experimental-utils/4.21.0_eslint@7.24.0+typescript@4.2.4:
+    resolution: {integrity: sha512-cEbgosW/tUFvKmkg3cU7LBoZhvUs+ZPVM9alb25XvR0dal4qHL3SiUqHNrzoWSxaXA9gsifrYrS1xdDV6w/gIA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
       eslint: '*'
     dependencies:
       '@types/json-schema': 7.0.7
-      '@typescript-eslint/scope-manager': 4.19.0
-      '@typescript-eslint/types': 4.19.0
-      '@typescript-eslint/typescript-estree': 4.19.0_typescript@4.2.3
-      eslint: 7.23.0
+      '@typescript-eslint/scope-manager': 4.21.0
+      '@typescript-eslint/types': 4.21.0
+      '@typescript-eslint/typescript-estree': 4.21.0_typescript@4.2.4
+      eslint: 7.24.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
     transitivePeerDependencies:
@@ -1561,8 +556,8 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/4.19.0_eslint@7.23.0+typescript@4.2.3:
-    resolution: {integrity: sha512-/uabZjo2ZZhm66rdAu21HA8nQebl3lAIDcybUoOxoI7VbZBYavLIwtOOmykKCJy+Xq6Vw6ugkiwn8Js7D6wieA==}
+  /@typescript-eslint/parser/4.21.0_eslint@7.24.0+typescript@4.2.4:
+    resolution: {integrity: sha512-eyNf7QmE5O/l1smaQgN0Lj2M/1jOuNg2NrBm1dqqQN0sVngTLyw8tdCbih96ixlhbF1oINoN8fDCyEH9SjLeIA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
       eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -1571,31 +566,31 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 4.19.0
-      '@typescript-eslint/types': 4.19.0
-      '@typescript-eslint/typescript-estree': 4.19.0_typescript@4.2.3
+      '@typescript-eslint/scope-manager': 4.21.0
+      '@typescript-eslint/types': 4.21.0
+      '@typescript-eslint/typescript-estree': 4.21.0_typescript@4.2.4
       debug: 4.3.1
-      eslint: 7.23.0
-      typescript: 4.2.3
+      eslint: 7.24.0
+      typescript: 4.2.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager/4.19.0:
-    resolution: {integrity: sha512-GGy4Ba/hLXwJXygkXqMzduqOMc+Na6LrJTZXJWVhRrSuZeXmu8TAnniQVKgj8uTRKe4igO2ysYzH+Np879G75g==}
+  /@typescript-eslint/scope-manager/4.21.0:
+    resolution: {integrity: sha512-kfOjF0w1Ix7+a5T1knOw00f7uAP9Gx44+OEsNQi0PvvTPLYeXJlsCJ4tYnDj5PQEYfpcgOH5yBlw7K+UEI9Agw==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     dependencies:
-      '@typescript-eslint/types': 4.19.0
-      '@typescript-eslint/visitor-keys': 4.19.0
+      '@typescript-eslint/types': 4.21.0
+      '@typescript-eslint/visitor-keys': 4.21.0
     dev: true
 
-  /@typescript-eslint/types/4.19.0:
-    resolution: {integrity: sha512-A4iAlexVvd4IBsSTNxdvdepW0D4uR/fwxDrKUa+iEY9UWvGREu2ZyB8ylTENM1SH8F7bVC9ac9+si3LWNxcBuA==}
+  /@typescript-eslint/types/4.21.0:
+    resolution: {integrity: sha512-+OQaupjGVVc8iXbt6M1oZMwyKQNehAfLYJJ3SdvnofK2qcjfor9pEM62rVjBknhowTkh+2HF+/KdRAc/wGBN2w==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     dev: true
 
-  /@typescript-eslint/typescript-estree/4.19.0_typescript@4.2.3:
-    resolution: {integrity: sha512-3xqArJ/A62smaQYRv2ZFyTA+XxGGWmlDYrsfZG68zJeNbeqRScnhf81rUVa6QG4UgzHnXw5VnMT5cg75dQGDkA==}
+  /@typescript-eslint/typescript-estree/4.21.0_typescript@4.2.4:
+    resolution: {integrity: sha512-ZD3M7yLaVGVYLw4nkkoGKumb7Rog7QID9YOWobFDMQKNl+vPxqVIW/uDk+MDeGc+OHcoG2nJ2HphwiPNajKw3w==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
       typescript: '*'
@@ -1603,23 +598,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 4.19.0
-      '@typescript-eslint/visitor-keys': 4.19.0
+      '@typescript-eslint/types': 4.21.0
+      '@typescript-eslint/visitor-keys': 4.21.0
       debug: 4.3.1
       globby: 11.0.3
       is-glob: 4.0.1
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.2.3
-      typescript: 4.2.3
+      tsutils: 3.21.0_typescript@4.2.4
+      typescript: 4.2.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/visitor-keys/4.19.0:
-    resolution: {integrity: sha512-aGPS6kz//j7XLSlgpzU2SeTqHPsmRYxFztj2vPuMMFJXZudpRSehE3WCV+BaxwZFvfAqMoSd86TEuM0PQ59E/A==}
+  /@typescript-eslint/visitor-keys/4.21.0:
+    resolution: {integrity: sha512-dH22dROWGi5Z6p+Igc8bLVLmwy7vEe8r+8c+raPQU0LxgogPUrRAtRGtvBWmlr9waTu3n+QLt/qrS/hWzk1x5w==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     dependencies:
-      '@typescript-eslint/types': 4.19.0
+      '@typescript-eslint/types': 4.21.0
       eslint-visitor-keys: 2.0.0
     dev: true
 
@@ -1888,7 +883,7 @@ packages:
       js-tokens: 3.0.2
     dev: true
 
-  /babel-eslint/10.1.0_eslint@7.23.0:
+  /babel-eslint/10.1.0_eslint@7.24.0:
     resolution: {integrity: sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==}
     engines: {node: '>=6'}
     deprecated: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.
@@ -1899,7 +894,7 @@ packages:
       '@babel/parser': 7.13.12
       '@babel/traverse': 7.13.0
       '@babel/types': 7.13.12
-      eslint: 7.23.0
+      eslint: 7.24.0
       eslint-visitor-keys: 1.3.0
       resolve: 1.20.0
     transitivePeerDependencies:
@@ -1921,125 +916,6 @@ packages:
     resolution: {integrity: sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=}
     dependencies:
       babel-runtime: 6.26.0
-    dev: true
-
-  /babel-plugin-add-module-exports/1.0.4:
-    resolution: {integrity: sha512-g+8yxHUZ60RcyaUpfNzy56OtWW+x9cyEe9j+CranqLiqbju2yf/Cy6ZtYK40EZxtrdHllzlVZgLmcOUCTlJ7Jg==}
-    dev: true
-
-  /babel-plugin-codegen/4.1.4:
-    resolution: {integrity: sha512-WWqjrCgi/+bOA9Vnx0k6tbuyDVzJaMFcBlzBpw02r9yrW8W4qWu+ObZE8lbM1g57IX+tHHS4WbO0zW40sDLGPA==}
-    engines: {node: '>=10', npm: '>=6'}
-    dependencies:
-      '@babel/runtime': 7.12.5
-      babel-plugin-macros: 3.0.1
-      require-from-string: 2.0.2
-    dev: true
-
-  /babel-plugin-dynamic-import-node/2.3.3:
-    resolution: {integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==}
-    dependencies:
-      object.assign: 4.1.2
-    dev: true
-
-  /babel-plugin-macros/2.8.0:
-    resolution: {integrity: sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==}
-    dependencies:
-      '@babel/runtime': 7.12.5
-      cosmiconfig: 6.0.0
-      resolve: 1.19.0
-    dev: true
-
-  /babel-plugin-macros/3.0.1:
-    resolution: {integrity: sha512-CKt4+Oy9k2wiN+hT1uZzOw7d8zb1anbQpf7KLwaaXRCi/4pzKdFKHf7v5mvoPmjkmxshh7eKZQuRop06r5WP4w==}
-    engines: {node: '>=10', npm: '>=6'}
-    dependencies:
-      '@babel/runtime': 7.12.5
-      cosmiconfig: 7.0.0
-      resolve: 1.19.0
-    dev: true
-
-  /babel-plugin-polyfill-corejs2/0.1.10:
-    resolution: {integrity: sha512-DO95wD4g0A8KRaHKi0D51NdGXzvpqVLnLu5BTvDlpqUEpTmeEtypgC1xqesORaWmiUOQI14UHKlzNd9iZ2G3ZA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.13.11
-      '@babel/helper-define-polyfill-provider': 0.1.5
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /babel-plugin-polyfill-corejs3/0.1.7:
-    resolution: {integrity: sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-define-polyfill-provider': 0.1.5
-      core-js-compat: 3.9.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /babel-plugin-polyfill-regenerator/0.1.6:
-    resolution: {integrity: sha512-OUrYG9iKPKz8NxswXbRAdSwF0GhRdIEMTloQATJi4bDuFqrXaXcCUT/VGNrr8pBcjMh1RxZ7Xt9cytVJTJfvMg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-define-polyfill-provider': 0.1.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /babel-plugin-preval/5.0.0:
-    resolution: {integrity: sha512-8DqJq6/LPUjSZ0Qq6bVIFpsj2flCEE0Cbnbut9TvGU6jP9g3dOWEXtQ/sdvsA9d6souza8eNGh04WRXpuH9ThA==}
-    engines: {node: '>=10', npm: '>=6'}
-    dependencies:
-      '@babel/runtime': 7.12.5
-      babel-plugin-macros: 2.8.0
-      require-from-string: 2.0.2
-    dev: true
-
-  /babel-plugin-transform-not-strict/0.3.1:
-    resolution: {integrity: sha512-1m9IY7AYL84Pj0UWpWizDdI/uuKFp+UjBqHBuSsJSlf8//yK3RfQXWVxVXEeYNgUPa36bCIFeVIeE2cFuWxJGA==}
-    peerDependencies:
-      '@babel/core': ^7
-    dev: true
-
-  /babel-preset-atomic/3.0.3:
-    resolution: {integrity: sha512-bKlcBqmfyJirw0ZwzNi0O/0pRZJhcjxeRuiOgNP5Fe0cAOIaN9W1xhcdk5A7kQOBU0eC/m3OhTwJJPJb58cM8A==}
-    peerDependencies:
-      '@babel/cli': ^7
-      '@babel/core': ^7
-    dependencies:
-      '@babel/plugin-proposal-class-properties': 7.13.0
-      '@babel/plugin-proposal-decorators': 7.13.5
-      '@babel/plugin-proposal-do-expressions': 7.12.13
-      '@babel/plugin-proposal-export-default-from': 7.12.13
-      '@babel/plugin-proposal-export-namespace-from': 7.12.13
-      '@babel/plugin-proposal-function-bind': 7.12.13
-      '@babel/plugin-proposal-function-sent': 7.12.13
-      '@babel/plugin-proposal-json-strings': 7.13.8
-      '@babel/plugin-proposal-logical-assignment-operators': 7.13.8
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.13.8
-      '@babel/plugin-proposal-numeric-separator': 7.12.13
-      '@babel/plugin-proposal-optional-chaining': 7.13.8
-      '@babel/plugin-proposal-pipeline-operator': 7.12.13
-      '@babel/plugin-proposal-private-methods': 7.13.0
-      '@babel/plugin-proposal-throw-expressions': 7.12.13
-      '@babel/plugin-syntax-dynamic-import': 7.8.3
-      '@babel/plugin-syntax-import-meta': 7.10.4
-      '@babel/plugin-transform-reserved-words': 7.12.13
-      '@babel/preset-env': 7.13.10
-      '@babel/preset-flow': 7.12.13
-      '@babel/preset-react': 7.12.13
-      babel-plugin-add-module-exports: 1.0.4
-      babel-plugin-codegen: 4.1.4
-      babel-plugin-preval: 5.0.0
-      babel-plugin-transform-not-strict: 0.3.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /babel-runtime/6.26.0:
@@ -2134,7 +1010,7 @@ packages:
       camelcase: 6.2.0
       chalk: 4.1.0
       cli-boxes: 2.2.1
-      string-width: 4.2.0
+      string-width: 4.2.2
       type-fest: 0.20.2
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
@@ -2152,18 +1028,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
-    dev: true
-
-  /browserslist/4.16.0:
-    resolution: {integrity: sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001168
-      colorette: 1.2.1
-      electron-to-chromium: 1.3.629
-      escalade: 3.1.1
-      node-releases: 1.1.67
     dev: true
 
   /browserslist/4.16.3:
@@ -2267,10 +1131,6 @@ packages:
   /camelcase/6.2.0:
     resolution: {integrity: sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==}
     engines: {node: '>=10'}
-    dev: true
-
-  /caniuse-lite/1.0.30001168:
-    resolution: {integrity: sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ==}
     dev: true
 
   /caniuse-lite/1.0.30001203:
@@ -2480,7 +1340,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       dot-prop: 5.3.0
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.6
       make-dir: 3.1.0
       unique-string: 2.0.0
       write-file-atomic: 3.0.3
@@ -2512,13 +1372,6 @@ packages:
       safe-buffer: 5.1.2
     dev: true
 
-  /core-js-compat/3.9.1:
-    resolution: {integrity: sha512-jXAirMQxrkbiiLsCx9bQPJFA6llDadKMpYrBJQJ3/c4/vsPP/fAf29h24tviRlvwUL6AmY5CHLu2GvjuYviQqA==}
-    dependencies:
-      browserslist: 4.16.3
-      semver: 7.0.0
-    dev: true
-
   /core-js-pure/3.9.1:
     resolution: {integrity: sha512-laz3Zx0avrw9a4QEIdmIblnVuJz8W51leY9iLThatCsFawWxC3sE4guASC78JbCin+DkwMpCdp1AVAuzL/GN7A==}
     requiresBuild: true
@@ -2532,28 +1385,6 @@ packages:
 
   /core-util-is/1.0.2:
     resolution: {integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=}
-    dev: true
-
-  /cosmiconfig/6.0.0:
-    resolution: {integrity: sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@types/parse-json': 4.0.0
-      import-fresh: 3.2.2
-      parse-json: 5.1.0
-      path-type: 4.0.0
-      yaml: 1.10.0
-    dev: true
-
-  /cosmiconfig/7.0.0:
-    resolution: {integrity: sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==}
-    engines: {node: '>=10'}
-    dependencies:
-      '@types/parse-json': 4.0.0
-      import-fresh: 3.2.2
-      parse-json: 5.1.0
-      path-type: 4.0.0
-      yaml: 1.10.0
     dev: true
 
   /cross-env/7.0.3:
@@ -2740,7 +1571,15 @@ packages:
   /dom-serializer/0.2.2:
     resolution: {integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==}
     dependencies:
-      domelementtype: 2.1.0
+      domelementtype: 2.2.0
+      entities: 2.2.0
+    dev: true
+
+  /dom-serializer/1.3.1:
+    resolution: {integrity: sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==}
+    dependencies:
+      domelementtype: 2.2.0
+      domhandler: 4.1.0
       entities: 2.2.0
     dev: true
 
@@ -2752,10 +1591,21 @@ packages:
     resolution: {integrity: sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==}
     dev: true
 
+  /domelementtype/2.2.0:
+    resolution: {integrity: sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==}
+    dev: true
+
   /domhandler/2.3.0:
     resolution: {integrity: sha1-LeWaCCLVAn+r/28DLCsloqir5zg=}
     dependencies:
       domelementtype: 1.3.1
+    dev: true
+
+  /domhandler/4.1.0:
+    resolution: {integrity: sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.2.0
     dev: true
 
   /domutils/1.5.1:
@@ -2763,6 +1613,14 @@ packages:
     dependencies:
       dom-serializer: 0.2.2
       domelementtype: 1.3.1
+    dev: true
+
+  /domutils/2.5.2:
+    resolution: {integrity: sha512-MHTthCb1zj8f1GVfRpeZUbohQf/HdBos0oX5gZcQFepOZPLLRyj6Wn7XS7EMnY7CVpwv8863u2vyE83Hfu28HQ==}
+    dependencies:
+      dom-serializer: 1.3.1
+      domelementtype: 2.2.0
+      domhandler: 4.1.0
     dev: true
 
   /dot-prop/5.3.0:
@@ -2781,10 +1639,6 @@ packages:
     dependencies:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
-    dev: true
-
-  /electron-to-chromium/1.3.629:
-    resolution: {integrity: sha512-iSPPJtPvHrMAvYOt+9cdbDmTasPqwnwz4lkP8Dn200gDNUBQOLQ96xUsWXBwXslAo5XxdoXAoQQ3RAy4uao9IQ==}
     dev: true
 
   /electron-to-chromium/1.3.693:
@@ -2944,7 +1798,7 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: true
 
-  /eslint-config-airbnb-base/14.2.1_3067c095822f9ee95e5e60ccdfea7e7c:
+  /eslint-config-airbnb-base/14.2.1_dc9d9d711f9715ea38ced5881f20889e:
     resolution: {integrity: sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==}
     engines: {node: '>= 6'}
     peerDependencies:
@@ -2952,13 +1806,13 @@ packages:
       eslint-plugin-import: ^2.22.1
     dependencies:
       confusing-browser-globals: 1.0.10
-      eslint: 7.23.0
-      eslint-plugin-import: 2.22.1_eslint@7.23.0
+      eslint: 7.24.0
+      eslint-plugin-import: 2.22.1_eslint@7.24.0
       object.assign: 4.1.2
       object.entries: 1.1.3
     dev: true
 
-  /eslint-config-airbnb/18.2.1_25f08fd9cd94a749b579bb92da57b849:
+  /eslint-config-airbnb/18.2.1_2650335cf7e827a63caa122de8e0d1a8:
     resolution: {integrity: sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==}
     engines: {node: '>= 6'}
     peerDependencies:
@@ -2968,49 +1822,48 @@ packages:
       eslint-plugin-react: ^7.21.5
       eslint-plugin-react-hooks: ^4 || ^3 || ^2.3.0 || ^1.7.0
     dependencies:
-      eslint: 7.23.0
-      eslint-config-airbnb-base: 14.2.1_3067c095822f9ee95e5e60ccdfea7e7c
-      eslint-plugin-import: 2.22.1_eslint@7.23.0
-      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.23.0
-      eslint-plugin-react: 7.23.1_eslint@7.23.0
+      eslint: 7.24.0
+      eslint-config-airbnb-base: 14.2.1_dc9d9d711f9715ea38ced5881f20889e
+      eslint-plugin-import: 2.22.1_eslint@7.24.0
+      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.24.0
+      eslint-plugin-react: 7.23.1_eslint@7.24.0
       object.assign: 4.1.2
       object.entries: 1.1.3
     dev: true
 
-  /eslint-config-atomic/1.12.4_eslint@7.23.0:
-    resolution: {integrity: sha512-hsdvWQAhXvYY5B94RTDCtT1YMmOdZ4JSVuE45hANcTKYiIsv9LAyW0I05Cujrg60W0TXrfn0gmaTefBWXTTx2w==}
-    peerDependencies:
-      eslint: '>=7'
+  /eslint-config-atomic/1.14.0:
+    resolution: {integrity: sha512-c6q/nQMK0ZT02Nrvlv84R9yL0o2FMwl9i6/wVh2sQV6EDVAUR64CRIxgJ4/5ODHJN1Yfe06E/Yyi1Od4wTuURw==}
     dependencies:
       '@babel/core': 7.13.10
-      '@typescript-eslint/eslint-plugin': 4.19.0_821acdc8bc493ad1aa2628c9b724d688
-      '@typescript-eslint/parser': 4.19.0_eslint@7.23.0+typescript@4.2.3
-      babel-eslint: 10.1.0_eslint@7.23.0
+      '@typescript-eslint/eslint-plugin': 4.21.0_bb1772e1f887ed78c68f06416685750e
+      '@typescript-eslint/parser': 4.21.0_eslint@7.24.0+typescript@4.2.4
+      babel-eslint: 10.1.0_eslint@7.24.0
       coffeescript: 1.12.7
-      eslint: 7.23.0
-      eslint-config-prettier: 8.1.0_eslint@7.23.0
-      eslint-plugin-coffee: 0.1.14_eslint@7.23.0
-      eslint-plugin-import: 2.22.1_eslint@7.23.0
+      eslint: 7.24.0
+      eslint-config-prettier: 8.1.0_eslint@7.24.0
+      eslint-plugin-coffee: 0.1.14_eslint@7.24.0
+      eslint-plugin-html: 6.1.2
+      eslint-plugin-import: 2.22.1_eslint@7.24.0
       eslint-plugin-json: 2.1.2
-      eslint-plugin-node: 11.1.0_eslint@7.23.0
+      eslint-plugin-node: 11.1.0_eslint@7.24.0
       eslint-plugin-only-warn: 1.0.2
       eslint-plugin-optimize-regex: 1.2.0
-      eslint-plugin-react: 7.23.1_eslint@7.23.0
+      eslint-plugin-react: 7.23.1_eslint@7.24.0
       eslint-plugin-yaml: 0.4.1
       prettier: 2.2.1
-      typescript: 4.2.3
+      typescript: 4.2.4
     transitivePeerDependencies:
       - eslint-plugin-react-hooks
       - supports-color
     dev: true
 
-  /eslint-config-prettier/8.1.0_eslint@7.23.0:
+  /eslint-config-prettier/8.1.0_eslint@7.24.0:
     resolution: {integrity: sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 7.23.0
+      eslint: 7.24.0
     dev: true
 
   /eslint-import-resolver-node/0.3.4:
@@ -3028,7 +1881,7 @@ packages:
       pkg-dir: 2.0.0
     dev: true
 
-  /eslint-plugin-coffee/0.1.14_eslint@7.23.0:
+  /eslint-plugin-coffee/0.1.14_eslint@7.24.0:
     resolution: {integrity: sha512-JwBminIlHz7XqZ8kbpNHDMG9y/tsHX8mwMZBxZaAlguyXIfYTrnY/nc+6+/X/DXfA//zDCs/lNARDciW3iJCOQ==}
     peerDependencies:
       eslint: '>=6.0.0'
@@ -3038,13 +1891,13 @@ packages:
       babylon: 7.0.0-beta.47
       coffeescript: 2.5.1
       doctrine: 2.1.0
-      eslint: 7.23.0
-      eslint-config-airbnb: 18.2.1_25f08fd9cd94a749b579bb92da57b849
-      eslint-config-airbnb-base: 14.2.1_3067c095822f9ee95e5e60ccdfea7e7c
-      eslint-plugin-import: 2.22.1_eslint@7.23.0
-      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.23.0
-      eslint-plugin-react: 7.23.1_eslint@7.23.0
-      eslint-plugin-react-native: 3.10.0_eslint@7.23.0
+      eslint: 7.24.0
+      eslint-config-airbnb: 18.2.1_2650335cf7e827a63caa122de8e0d1a8
+      eslint-config-airbnb-base: 14.2.1_dc9d9d711f9715ea38ced5881f20889e
+      eslint-plugin-import: 2.22.1_eslint@7.24.0
+      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.24.0
+      eslint-plugin-react: 7.23.1_eslint@7.24.0
+      eslint-plugin-react-native: 3.10.0_eslint@7.24.0
       eslint-scope: 3.7.3
       eslint-utils: 1.4.3
       eslint-visitor-keys: 1.3.0
@@ -3055,18 +1908,24 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-es/3.0.1_eslint@7.23.0:
+  /eslint-plugin-es/3.0.1_eslint@7.24.0:
     resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
-      eslint: 7.23.0
+      eslint: 7.24.0
       eslint-utils: 2.1.0
       regexpp: 3.1.0
     dev: true
 
-  /eslint-plugin-import/2.22.1_eslint@7.23.0:
+  /eslint-plugin-html/6.1.2:
+    resolution: {integrity: sha512-bhBIRyZFqI4EoF12lGDHAmgfff8eLXx6R52/K3ESQhsxzCzIE6hdebS7Py651f7U3RBotqroUnC3L29bR7qJWQ==}
+    dependencies:
+      htmlparser2: 6.1.0
+    dev: true
+
+  /eslint-plugin-import/2.22.1_eslint@7.24.0:
     resolution: {integrity: sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3077,7 +1936,7 @@ packages:
       contains-path: 0.1.0
       debug: 2.6.9
       doctrine: 1.5.0
-      eslint: 7.23.0
+      eslint: 7.24.0
       eslint-import-resolver-node: 0.3.4
       eslint-module-utils: 2.6.0
       has: 1.0.3
@@ -3096,7 +1955,7 @@ packages:
       vscode-json-languageservice: 3.11.0
     dev: true
 
-  /eslint-plugin-jsx-a11y/6.4.1_eslint@7.23.0:
+  /eslint-plugin-jsx-a11y/6.4.1_eslint@7.24.0:
     resolution: {integrity: sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -3110,20 +1969,20 @@ packages:
       axobject-query: 2.2.0
       damerau-levenshtein: 1.0.6
       emoji-regex: 9.2.2
-      eslint: 7.23.0
+      eslint: 7.24.0
       has: 1.0.3
       jsx-ast-utils: 3.2.0
       language-tags: 1.0.5
     dev: true
 
-  /eslint-plugin-node/11.1.0_eslint@7.23.0:
+  /eslint-plugin-node/11.1.0_eslint@7.24.0:
     resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=5.16.0'
     dependencies:
-      eslint: 7.23.0
-      eslint-plugin-es: 3.0.1_eslint@7.23.0
+      eslint: 7.24.0
+      eslint-plugin-es: 3.0.1_eslint@7.24.0
       eslint-utils: 2.1.0
       ignore: 5.1.8
       minimatch: 3.0.4
@@ -3147,19 +2006,19 @@ packages:
     resolution: {integrity: sha512-9aEPf1JEpiTjcFAmmyw8eiIXmcNZOqaZyHO77wgm0/dWfT/oxC1SrIq8ET38pMxHYrcB6Uew+TzUVsBeczF88g==}
     dev: true
 
-  /eslint-plugin-react-native/3.10.0_eslint@7.23.0:
+  /eslint-plugin-react-native/3.10.0_eslint@7.24.0:
     resolution: {integrity: sha512-4f5+hHYYq5wFhB5eptkPEAR7FfvqbS7AzScUOANfAMZtYw5qgnCxRq45bpfBaQF+iyPMim5Q8pubcpvLv75NAg==}
     peerDependencies:
       eslint: ^3.17.0 || ^4 || ^5 || ^6 || ^7
     dependencies:
       '@babel/traverse': 7.13.0
-      eslint: 7.23.0
+      eslint: 7.24.0
       eslint-plugin-react-native-globals: 0.1.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-react/7.23.1_eslint@7.23.0:
+  /eslint-plugin-react/7.23.1_eslint@7.24.0:
     resolution: {integrity: sha512-MvFGhZjI8Z4HusajmSw0ougGrq3Gs4vT/0WgwksZgf5RrLrRa2oYAw56okU4tZJl8+j7IYNuTM+2RnFEuTSdRQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3168,7 +2027,7 @@ packages:
       array-includes: 3.1.3
       array.prototype.flatmap: 1.2.4
       doctrine: 2.1.0
-      eslint: 7.23.0
+      eslint: 7.24.0
       has: 1.0.3
       jsx-ast-utils: 3.2.0
       minimatch: 3.0.4
@@ -3227,8 +2086,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint/7.23.0:
-    resolution: {integrity: sha512-kqvNVbdkjzpFy0XOszNwjkKzZ+6TcwCQ/h+ozlcIWwaimBBuhlQ4nN6kbiM2L+OjDcznkTJxzYfRFH92sx4a0Q==}
+  /eslint/7.24.0:
+    resolution: {integrity: sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==}
     engines: {node: ^10.12.0 || >=12.0.0}
     hasBin: true
     dependencies:
@@ -3619,18 +2478,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /globby/11.0.2:
-    resolution: {integrity: sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==}
-    engines: {node: '>=10'}
-    dependencies:
-      array-union: 2.1.0
-      dir-glob: 3.0.1
-      fast-glob: 3.2.5
-      ignore: 5.1.8
-      merge2: 1.4.1
-      slash: 3.0.0
-    dev: true
-
   /globby/11.0.3:
     resolution: {integrity: sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==}
     engines: {node: '>=10'}
@@ -3667,10 +2514,6 @@ packages:
       p-cancelable: 1.1.0
       to-readable-stream: 1.0.0
       url-parse-lax: 3.0.0
-    dev: true
-
-  /graceful-fs/4.2.4:
-    resolution: {integrity: sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==}
     dev: true
 
   /graceful-fs/4.2.6:
@@ -3754,8 +2597,8 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /hosted-git-info/4.0.1:
-    resolution: {integrity: sha512-eT7NrxAsppPRQEBSwKSosReE+v8OzABwEScQYk5d4uxaEPlzxTIku7LINXtBGalthkLhJnq5lBI89PfK43zAKg==}
+  /hosted-git-info/4.0.2:
+    resolution: {integrity: sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==}
     engines: {node: '>=10'}
     dependencies:
       lru-cache: 6.0.0
@@ -3769,6 +2612,15 @@ packages:
       domutils: 1.5.1
       entities: 1.0.0
       readable-stream: 1.1.14
+    dev: true
+
+  /htmlparser2/6.1.0:
+    resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
+    dependencies:
+      domelementtype: 2.1.0
+      domhandler: 4.1.0
+      domutils: 2.5.2
+      entities: 2.2.0
     dev: true
 
   /http-cache-semantics/4.1.0:
@@ -3837,14 +2689,6 @@ packages:
   /ignore/5.1.8:
     resolution: {integrity: sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==}
     engines: {node: '>= 4'}
-    dev: true
-
-  /import-fresh/3.2.2:
-    resolution: {integrity: sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==}
-    engines: {node: '>=6'}
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
     dev: true
 
   /import-fresh/3.3.0:
@@ -4248,11 +3092,6 @@ packages:
     resolution: {integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=}
     dev: true
 
-  /jsesc/0.5.0:
-    resolution: {integrity: sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=}
-    hasBin: true
-    dev: true
-
   /jsesc/2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
@@ -4313,14 +3152,6 @@ packages:
 
   /json5/1.0.1:
     resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
-    hasBin: true
-    dependencies:
-      minimist: 1.2.5
-    dev: true
-
-  /json5/2.1.3:
-    resolution: {integrity: sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==}
-    engines: {node: '>=6'}
     hasBin: true
     dependencies:
       minimist: 1.2.5
@@ -4417,10 +3248,6 @@ packages:
       ini: 1.3.8
     dev: true
 
-  /lines-and-columns/1.1.6:
-    resolution: {integrity: sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=}
-    dev: true
-
   /linguist-languages/7.13.0:
     resolution: {integrity: sha512-n1X6l+YYbEDtXE9tDr8nYZAgeuKw+qBFvYGzIGltw3Z3oJwS+4vyVtFG5UFa71kvmPWMS3RT/yB95RWzD7MrVQ==}
     dev: true
@@ -4466,10 +3293,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-locate: 5.0.0
-    dev: true
-
-  /lodash.debounce/4.0.8:
-    resolution: {integrity: sha1-gteb/zCmfEAF/9XiUVMArZyk168=}
     dev: true
 
   /lodash/4.17.20:
@@ -4758,18 +3581,14 @@ packages:
     dependencies:
       env-paths: 2.2.0
       glob: 7.1.6
-      graceful-fs: 4.2.4
+      graceful-fs: 4.2.6
       nopt: 5.0.0
       npmlog: 4.1.2
       request: 2.88.2
       rimraf: 3.0.2
-      semver: 7.3.4
+      semver: 7.3.5
       tar: 6.1.0
       which: 2.0.2
-    dev: true
-
-  /node-releases/1.1.67:
-    resolution: {integrity: sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==}
     dev: true
 
   /node-releases/1.1.71:
@@ -4809,8 +3628,8 @@ packages:
       npm-normalize-package-bin: 1.0.1
     dev: true
 
-  /npm-check-updates/11.3.0:
-    resolution: {integrity: sha512-7GMDj40cWw/nRn3BsN+20ca3T6CvHqIiFhooVa5a3VybrS7TNBdbR3/BIi9dw4vFORgFZw/OsW3ZtRTFamnPDQ==}
+  /npm-check-updates/11.4.1:
+    resolution: {integrity: sha512-bWElM5CeJ9gA/wvtqB4ljcKzAZ3BlPM2g/7mVi8mPdCR2N6dhgS4q5GCzQn4ZvpeKSFll3bUGkiR/lgSQOlN8Q==}
     engines: {node: '>=10.17'}
     hasBin: true
     dependencies:
@@ -4821,8 +3640,8 @@ packages:
       find-up: 5.0.0
       fp-and-or: 0.1.3
       get-stdin: 8.0.0
-      globby: 11.0.2
-      hosted-git-info: 4.0.1
+      globby: 11.0.3
+      hosted-git-info: 4.0.2
       json-parse-helpfulerror: 1.0.3
       jsonlines: 0.1.1
       libnpmconfig: 1.2.1
@@ -4830,14 +3649,14 @@ packages:
       mem: 8.1.0
       minimatch: 3.0.4
       p-map: 4.0.0
-      pacote: 11.3.0
+      pacote: 11.3.1
       parse-github-url: 1.0.2
       progress: 2.0.3
-      prompts: 2.4.0
+      prompts: 2.4.1
       rc-config-loader: 4.0.0
       remote-git-tags: 3.0.0
       rimraf: 3.0.2
-      semver: 7.3.4
+      semver: 7.3.5
       semver-utils: 1.1.4
       spawn-please: 1.0.0
       update-notifier: 5.1.0
@@ -4849,7 +3668,7 @@ packages:
     resolution: {integrity: sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.3.4
+      semver: 7.3.5
     dev: true
 
   /npm-normalize-package-bin/1.0.1:
@@ -4861,7 +3680,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 3.0.7
-      semver: 7.3.4
+      semver: 7.3.5
       validate-npm-package-name: 3.0.0
     dev: true
 
@@ -4881,7 +3700,7 @@ packages:
     dependencies:
       npm-install-checks: 4.0.0
       npm-package-arg: 8.1.0
-      semver: 7.3.4
+      semver: 7.3.5
     dev: true
 
   /npm-registry-fetch/9.0.0:
@@ -5092,8 +3911,8 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /pacote/11.3.0:
-    resolution: {integrity: sha512-cygprcGpEVqvDzpuPMkGVXW/ooc2ibpoosuJ4YHcUXozDs9VJP7Vha+41pYppG2MVNis4t1BB8IygIBh7vVr2Q==}
+  /pacote/11.3.1:
+    resolution: {integrity: sha512-TymtwoAG12cczsJIrwI/euOQKtjrQHlD0k0oyt9QSmZGpqa+KdlxKdWR/YUjYizkixaVyztxt/Wsfo8bL3A6Fg==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -5157,16 +3976,6 @@ packages:
     dependencies:
       error-ex: 1.3.2
       json-parse-better-errors: 1.0.2
-    dev: true
-
-  /parse-json/5.1.0:
-    resolution: {integrity: sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@babel/code-frame': 7.12.13
-      error-ex: 1.3.2
-      json-parse-even-better-errors: 2.3.1
-      lines-and-columns: 1.1.6
     dev: true
 
   /path-exists/3.0.0:
@@ -5320,8 +4129,8 @@ packages:
       retry: 0.12.0
     dev: true
 
-  /prompts/2.4.0:
-    resolution: {integrity: sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==}
+  /prompts/2.4.1:
+    resolution: {integrity: sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==}
     engines: {node: '>= 6'}
     dependencies:
       kleur: 3.0.3
@@ -5379,7 +4188,7 @@ packages:
     dependencies:
       debug: 4.3.1
       js-yaml: 4.0.0
-      json5: 2.1.3
+      json5: 2.2.0
       require-from-string: 2.0.2
     transitivePeerDependencies:
       - supports-color
@@ -5477,29 +4286,12 @@ packages:
       resolve: 1.19.0
     dev: true
 
-  /regenerate-unicode-properties/8.2.0:
-    resolution: {integrity: sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==}
-    engines: {node: '>=4'}
-    dependencies:
-      regenerate: 1.4.2
-    dev: true
-
-  /regenerate/1.4.2:
-    resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
-    dev: true
-
   /regenerator-runtime/0.11.1:
     resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==}
     dev: true
 
   /regenerator-runtime/0.13.7:
     resolution: {integrity: sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==}
-    dev: true
-
-  /regenerator-transform/0.14.5:
-    resolution: {integrity: sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==}
-    dependencies:
-      '@babel/runtime': 7.12.5
     dev: true
 
   /regexp-tree/0.1.23:
@@ -5528,18 +4320,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /regexpu-core/4.7.1:
-    resolution: {integrity: sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      regenerate: 1.4.2
-      regenerate-unicode-properties: 8.2.0
-      regjsgen: 0.5.2
-      regjsparser: 0.6.4
-      unicode-match-property-ecmascript: 1.0.4
-      unicode-match-property-value-ecmascript: 1.2.0
-    dev: true
-
   /registry-auth-token/4.2.1:
     resolution: {integrity: sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==}
     engines: {node: '>=6.0.0'}
@@ -5552,17 +4332,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       rc: 1.2.8
-    dev: true
-
-  /regjsgen/0.5.2:
-    resolution: {integrity: sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==}
-    dev: true
-
-  /regjsparser/0.6.4:
-    resolution: {integrity: sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==}
-    hasBin: true
-    dependencies:
-      jsesc: 0.5.0
     dev: true
 
   /remote-git-tags/3.0.0:
@@ -5675,35 +4444,33 @@ packages:
       assemblyscript: 0.17.13
     dev: true
 
-  /rollup-plugin-atomic/2.1.2_rollup@2.43.1:
-    resolution: {integrity: sha512-yV/lIW5TorWWIYC0ba6ICX6HnZRfbAfo6M/NhaGMtYU83qGW6DuI+MYsfQ+agLs32U2tuYtAsC+mXPYOezca7A==}
-    peerDependencies:
-      rollup: ^2
+  /rollup-plugin-atomic/2.3.0:
+    resolution: {integrity: sha512-3yMZpQCQpB/VPaU3nkc0QzNhRdfqoROknJ/V1STb0eMmctXx/Iz8WvAVL3UUBzUXyJC3lCrx/gaMCATMx/KeyA==}
     dependencies:
-      '@rollup/plugin-babel': 5.3.0_b71b3f5cf92718a15610ac8d891f611a
-      '@rollup/plugin-commonjs': 18.0.0_rollup@2.43.1
-      '@rollup/plugin-json': 4.1.0_rollup@2.43.1
-      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.43.1
-      '@rollup/plugin-replace': 2.4.2_rollup@2.43.1
-      '@rollup/plugin-typescript': 8.2.1_6677de9b412b48c22c27642d5fb54be4
-      '@rollup/plugin-wasm': 5.1.2_rollup@2.43.1
+      '@rollup/plugin-babel': 5.3.0_08db584e23334d2e829dd80bbfffb699
+      '@rollup/plugin-commonjs': 18.0.0_rollup@2.45.1
+      '@rollup/plugin-json': 4.1.0_rollup@2.45.1
+      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.45.1
+      '@rollup/plugin-replace': 2.4.2_rollup@2.45.1
+      '@rollup/plugin-typescript': 8.2.1_b51314abecd42a5fbdb6553ef5e24827
+      '@rollup/plugin-wasm': 5.1.2_rollup@2.45.1
       array-includes-any: 2.7.3
       csso-cli: 3.0.0
-      rollup: 2.43.1
+      rollup: 2.45.1
       rollup-plugin-assemblyscript: 2.0.0_assemblyscript@0.17.13
-      rollup-plugin-auto-external: 2.0.0_rollup@2.43.1
+      rollup-plugin-auto-external: 2.0.0_rollup@2.45.1
       rollup-plugin-coffee-script: 2.0.0_coffeescript@1.12.7
-      rollup-plugin-css-only: 3.1.0_rollup@2.43.1
+      rollup-plugin-css-only: 3.1.0_rollup@2.45.1
       rollup-plugin-execute: 1.1.1
-      rollup-plugin-sourcemaps: 0.6.3_rollup@2.43.1
-      rollup-plugin-terser: 7.0.2_rollup@2.43.1
-      rollup-plugin-visualizer: 4.2.2_rollup@2.43.1
-      tslib: 2.1.0
+      rollup-plugin-sourcemaps: 0.6.3_rollup@2.45.1
+      rollup-plugin-terser: 7.0.2_rollup@2.45.1
+      rollup-plugin-visualizer: 5.3.3_rollup@2.45.1
+      tslib: 2.2.0
     optionalDependencies:
       '@babel/core': 7.13.10
       assemblyscript: 0.17.13
       coffeescript: 1.12.7
-      typescript: 4.2.3
+      typescript: 4.2.4
     transitivePeerDependencies:
       - '@types/babel__core'
       - '@types/node'
@@ -5711,7 +4478,7 @@ packages:
       - supports-color
     dev: true
 
-  /rollup-plugin-auto-external/2.0.0_rollup@2.43.1:
+  /rollup-plugin-auto-external/2.0.0_rollup@2.45.1:
     resolution: {integrity: sha512-HQM3ZkZYfSam1uoZtAB9sK26EiAsfs1phrkf91c/YX+S07wugyRXSigBxrIwiLr5EPPilKYmoMxsrnlGBsXnuQ==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -5719,7 +4486,7 @@ packages:
     dependencies:
       builtins: 2.0.1
       read-pkg: 3.0.0
-      rollup: 2.43.1
+      rollup: 2.45.1
       safe-resolve: 1.0.0
       semver: 5.7.1
     dev: true
@@ -5735,14 +4502,14 @@ packages:
       rollup-pluginutils: 2.8.2
     dev: true
 
-  /rollup-plugin-css-only/3.1.0_rollup@2.43.1:
+  /rollup-plugin-css-only/3.1.0_rollup@2.45.1:
     resolution: {integrity: sha512-TYMOE5uoD76vpj+RTkQLzC9cQtbnJNktHPB507FzRWBVaofg7KhIqq1kGbcVOadARSozWF883Ho9KpSPKH8gqA==}
     engines: {node: '>=10.12.0'}
     peerDependencies:
       rollup: 1 || 2
     dependencies:
-      '@rollup/pluginutils': 4.1.0_rollup@2.43.1
-      rollup: 2.43.1
+      '@rollup/pluginutils': 4.1.0_rollup@2.45.1
+      rollup: 2.45.1
     dev: true
 
   /rollup-plugin-execute/1.1.1:
@@ -5758,7 +4525,7 @@ packages:
       resolve: 1.20.0
     dev: true
 
-  /rollup-plugin-sourcemaps/0.6.3_rollup@2.43.1:
+  /rollup-plugin-sourcemaps/0.6.3_rollup@2.45.1:
     resolution: {integrity: sha512-paFu+nT1xvuO1tPFYXGe+XnQvg4Hjqv/eIhG8i5EspfYYPBKL57X7iVbfv55aNVASg3dzWvES9dmWsL2KhfByw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -5768,33 +4535,33 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.43.1
-      rollup: 2.43.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.45.1
+      rollup: 2.45.1
       source-map-resolve: 0.6.0
     dev: true
 
-  /rollup-plugin-terser/7.0.2_rollup@2.43.1:
+  /rollup-plugin-terser/7.0.2_rollup@2.45.1:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
     peerDependencies:
       rollup: ^2.0.0
     dependencies:
       '@babel/code-frame': 7.12.13
       jest-worker: 26.6.2
-      rollup: 2.43.1
+      rollup: 2.45.1
       serialize-javascript: 4.0.0
       terser: 5.5.1
     dev: true
 
-  /rollup-plugin-visualizer/4.2.2_rollup@2.43.1:
-    resolution: {integrity: sha512-10/TsugsaQL5rdynl0lrklBngTtkRBESZdxUJy+3fN+xKqNdg5cr7JQU1OoPx4p5mhQ+nspa6EvX3qc8SsBvnA==}
-    engines: {node: '>=10'}
+  /rollup-plugin-visualizer/5.3.3_rollup@2.45.1:
+    resolution: {integrity: sha512-vDMnVckdRRTuxTOO17s1UHgbu/UQ9mVyDiMrSsC17GZB3lI0ZEo3sDwSaJnP03uohuW1Jb6v9N7RqRRFJgtkhw==}
+    engines: {node: '>=10.16'}
     hasBin: true
     peerDependencies:
-      rollup: '>=1.20.0'
+      rollup: ^2.0.0
     dependencies:
       nanoid: 3.1.22
       open: 7.4.2
-      rollup: 2.43.1
+      rollup: 2.45.1
       source-map: 0.7.3
       yargs: 16.2.0
     dev: true
@@ -5805,8 +4572,8 @@ packages:
       estree-walker: 0.6.1
     dev: true
 
-  /rollup/2.43.1:
-    resolution: {integrity: sha512-kvRE6VJbiv4d8m2nGeccc3qRpzOMghAhu2KeITjyZVCjneIFLPQ3zm2Wmqnl0LcUg3FvDaV0MfKnG4NCMbiSfw==}
+  /rollup/2.45.1:
+    resolution: {integrity: sha512-vPD+JoDj3CY8k6m1bLcAFttXMe78P4CMxoau0iLVS60+S9kLsv2379xaGy4NgYWu+h2WTlucpoLPAoUoixFBag==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -5854,19 +4621,6 @@ packages:
   /semver/6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
-    dev: true
-
-  /semver/7.0.0:
-    resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==}
-    hasBin: true
-    dev: true
-
-  /semver/7.3.4:
-    resolution: {integrity: sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
     dev: true
 
   /semver/7.3.5:
@@ -6088,15 +4842,6 @@ packages:
       emoji-regex: 7.0.3
       is-fullwidth-code-point: 2.0.0
       strip-ansi: 5.2.0
-    dev: true
-
-  /string-width/4.2.0:
-    resolution: {integrity: sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==}
-    engines: {node: '>=8'}
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.0
     dev: true
 
   /string-width/4.2.2:
@@ -6324,18 +5069,18 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tslib/2.1.0:
-    resolution: {integrity: sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==}
+  /tslib/2.2.0:
+    resolution: {integrity: sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==}
     dev: true
 
-  /tsutils/3.21.0_typescript@4.2.3:
+  /tsutils/3.21.0_typescript@4.2.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.2.3
+      typescript: 4.2.4
     dev: true
 
   /tunnel-agent/0.6.0:
@@ -6371,8 +5116,8 @@ packages:
       is-typedarray: 1.0.0
     dev: true
 
-  /typescript/4.2.3:
-    resolution: {integrity: sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==}
+  /typescript/4.2.4:
+    resolution: {integrity: sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
@@ -6388,29 +5133,6 @@ packages:
 
   /underscore/1.9.2:
     resolution: {integrity: sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==}
-    dev: true
-
-  /unicode-canonical-property-names-ecmascript/1.0.4:
-    resolution: {integrity: sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /unicode-match-property-ecmascript/1.0.4:
-    resolution: {integrity: sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==}
-    engines: {node: '>=4'}
-    dependencies:
-      unicode-canonical-property-names-ecmascript: 1.0.4
-      unicode-property-aliases-ecmascript: 1.1.0
-    dev: true
-
-  /unicode-match-property-value-ecmascript/1.2.0:
-    resolution: {integrity: sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /unicode-property-aliases-ecmascript/1.1.0:
-    resolution: {integrity: sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==}
-    engines: {node: '>=4'}
     dev: true
 
   /unique-filename/1.1.1:
@@ -6453,7 +5175,7 @@ packages:
       is-yarn-global: 0.3.0
       latest-version: 5.1.0
       pupa: 2.1.1
-      semver: 7.3.4
+      semver: 7.3.5
       semver-diff: 3.1.1
       xdg-basedir: 4.0.0
     dev: true
@@ -6591,7 +5313,7 @@ packages:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
     engines: {node: '>=8'}
     dependencies:
-      string-width: 4.2.0
+      string-width: 4.2.2
     dev: true
 
   /word-wrap/1.2.3:
@@ -6633,11 +5355,6 @@ packages:
 
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
-
-  /yaml/1.10.0:
-    resolution: {integrity: sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==}
-    engines: {node: '>= 6'}
     dev: true
 
   /yargs-parser/20.2.4:

--- a/src/binding/binding.ts
+++ b/src/binding/binding.ts
@@ -27,3 +27,82 @@ export declare function score(
 export declare function match(str: string, query: string, pathSeparator: string): Array<number>
 
 export declare function wrap(str: string, query: string, pathSeparator: string): string
+
+// Argument validators
+
+export function validate_filter(...args: Parameters<Zadeh["filter"]>) {
+  if (
+    !(
+      typeof args[0] === "string" &&
+      typeof args[1] === "number" &&
+      typeof args[2] === "boolean" &&
+      typeof args[3] === "boolean"
+    )
+  ) {
+    throw new Error(`Invalid arguments for filter: ${args}`)
+  }
+}
+
+export function validate_setArrayFiltererCandidates(...args: Parameters<Zadeh["setArrayFiltererCandidates"]>) {
+  if (!Array.isArray(args[0])) {
+    throw new Error(`Invalid arguments for setArrayFiltererCandidates: ${args}`)
+  }
+}
+
+export function validate_filterTree(...args: Parameters<Zadeh["filterTree"]>) {
+  if (
+    !(
+      typeof args[0] === "string" &&
+      typeof args[1] === "number" &&
+      typeof args[2] === "boolean" &&
+      typeof args[3] === "boolean"
+    )
+  ) {
+    throw new Error(`Invalid arguments for filterTree: ${args}`)
+  }
+}
+
+export function validate_setTreeFiltererCandidates(...args: Parameters<Zadeh["setTreeFiltererCandidates"]>) {
+  if (!Array.isArray(args[0])) {
+    throw new Error(`Invalid arguments for setTreeFiltererCandidates: ${args}`)
+  }
+}
+
+export function validate_score(...args: Parameters<typeof score>) {
+  if (
+    !(
+      typeof args[0] === "string" &&
+      typeof args[1] === "string" &&
+      typeof args[2] === "boolean" &&
+      typeof args[3] === "boolean"
+    )
+  ) {
+    throw new Error(`Invalid arguments for score: ${args}`)
+  }
+}
+
+export function validate_match(...args: Parameters<typeof match>) {
+  if (
+    !(
+      typeof args[0] === "string" &&
+      typeof args[1] === "string" &&
+      typeof args[2] === "string" &&
+      /** PathSeparator */ args[2].length === 1
+    )
+  ) {
+    throw new Error(`Invalid arguments for match: ${args}`)
+  }
+}
+
+export function validate_wrap(...args: Parameters<typeof wrap>) {
+  if (
+    !(
+      typeof args[0] === "string" &&
+      typeof args[1] === "string" &&
+      typeof args[2] === "string" &&
+      /** PathSeparator */ args[2].length === 1
+    )
+  ) {
+    throw new Error(`Invalid arguments for wrap: ${args}`)
+  }
+}

--- a/src/binding/index.ts
+++ b/src/binding/index.ts
@@ -25,7 +25,7 @@ export interface IOptions {
   useExtensionBonus?: boolean
 
   /**
-   * A path separator which is a string with length 1. Such as "/" or "\". By default, this is chosen based on the
+   * A path separator which is a string with length 1. Such as "/" or "". By default, this is chosen based on the
    * operating system.
    */
   pathSeparator?: "/" | "\\" | stringWithLength1

--- a/src/binding/index.ts
+++ b/src/binding/index.ts
@@ -12,6 +12,8 @@ const binding = nodeGypBuld(__dirname) as typeof Binding // __dirname relies on 
  ██████  ██         ██    ██  ██████  ██   ████ ███████
 */
 
+type stringWithLength1 = string
+
 export interface IOptions {
   /** @default false */
   allowErrors?: boolean
@@ -22,7 +24,11 @@ export interface IOptions {
   /** @default false */
   useExtensionBonus?: boolean
 
-  pathSeparator?: "/" | "\\" | string
+  /**
+   * A path separator which is a string with length 1. Such as "/" or "\". By default, this is chosen based on the
+   * operating system.
+   */
+  pathSeparator?: "/" | "\\" | stringWithLength1
 
   // TODO not implemented?
   // optCharRegEx?: RegExp
@@ -110,6 +116,8 @@ export class StringArrayFilterer {
    */
   setCandidates(candidates: Array<string>) {
     this.candidates = candidates
+
+    Binding.validate_setArrayFiltererCandidates(candidates)
     return this.obj.setArrayFiltererCandidates(candidates)
   }
 
@@ -122,12 +130,13 @@ export class StringArrayFilterer {
    */
   filter(query: string, options: StringArrayFilterOptions = {}): Array<string> {
     parseFilterOptions(options)
-    const res = this.obj.filter(
-      query,
-      options.maxResults as number /* numberified by parseFilterOptions */,
-      Boolean(options.usePathScoring),
-      Boolean(options.useExtensionBonus)
-    )
+
+    const maxResult = options.maxResults as number /* numberified by parseFilterOptions */
+    const usePathScoring = Boolean(options.usePathScoring)
+    const useExtensionBonus = Boolean(options.useExtensionBonus)
+
+    Binding.validate_filter(query, maxResult, usePathScoring, useExtensionBonus)
+    const res = this.obj.filter(query, maxResult, usePathScoring, useExtensionBonus)
     return res.map((ind: number) => this.candidates[ind])
   }
 }
@@ -164,6 +173,8 @@ export class ObjectArrayFilterer {
   setCandidates(candidates: Array<ObjectWithKey>, dataKey: string | number) {
     this.candidates = candidates
     const candidatesKeys = candidates.map((item) => item[dataKey])
+
+    Binding.validate_setArrayFiltererCandidates(candidatesKeys)
     this.obj.setArrayFiltererCandidates(candidatesKeys)
   }
 
@@ -176,12 +187,13 @@ export class ObjectArrayFilterer {
    */
   filter(query: string, options: ObjectArrayFilterOptions = {}): Array<ObjectWithKey> {
     parseFilterOptions(options)
-    const res = this.obj.filter(
-      query,
-      options.maxResults as number /* numberified by parseFilterOptions */,
-      Boolean(options.usePathScoring),
-      Boolean(options.useExtensionBonus)
-    )
+
+    const maxResult = options.maxResults as number /* numberified by parseFilterOptions */
+    const usePathScoring = Boolean(options.usePathScoring)
+    const useExtensionBonus = Boolean(options.useExtensionBonus)
+
+    Binding.validate_filter(query, maxResult, usePathScoring, useExtensionBonus)
+    const res = this.obj.filter(query, maxResult, usePathScoring, useExtensionBonus)
     return res.map((ind: number) => this.candidates[ind])
   }
 }
@@ -274,6 +286,8 @@ export class TreeFilterer<T extends Tree = Tree> {
    */
   setCandidates(candidates: Array<T>, dataKey: string = "data", childrenKey: string = "children") {
     this.candidates = candidates
+
+    Binding.validate_setTreeFiltererCandidates(candidates, dataKey, childrenKey)
     return this.obj.setTreeFiltererCandidates(candidates, dataKey, childrenKey)
   }
 
@@ -287,12 +301,13 @@ export class TreeFilterer<T extends Tree = Tree> {
    */
   filter(query: string, options: TreeFilterOptions = {}): TreeFilterResult[] {
     parseFilterOptions(options)
-    return this.obj.filterTree(
-      query,
-      options.maxResults as number /* numberified by parseFilterOptions */,
-      Boolean(options.usePathScoring),
-      Boolean(options.useExtensionBonus)
-    )
+
+    const maxResult = options.maxResults as number /* numberified by parseFilterOptions */
+    const usePathScoring = Boolean(options.usePathScoring)
+    const useExtensionBonus = Boolean(options.useExtensionBonus)
+
+    Binding.validate_filterTree(query, maxResult, usePathScoring, useExtensionBonus)
+    return this.obj.filterTree(query, maxResult, usePathScoring, useExtensionBonus)
   }
 }
 
@@ -348,7 +363,12 @@ export function score(candidate: string, query: string, options: IOptions = {}):
     return 0
   }
   parseOptions(options)
-  return binding.score(candidate, query, Boolean(options.usePathScoring), Boolean(options.useExtensionBonus))
+
+  const usePathScoring = Boolean(options.usePathScoring)
+  const useExtensionBonus = Boolean(options.useExtensionBonus)
+
+  Binding.validate_score(candidate, query, usePathScoring, useExtensionBonus)
+  return binding.score(candidate, query, usePathScoring, useExtensionBonus)
 }
 
 /*
@@ -369,7 +389,11 @@ export function match(str: string, query: string, options: IOptions = {}): numbe
     return Array.from(Array(str.length).keys())
   }
   parseOptions(options)
-  return binding.match(str, query, options.pathSeparator as string /* stringified by parseOption */)
+
+  const pathSeparator = options.pathSeparator as string /* stringified by parseOption */
+
+  Binding.validate_match(str, query, pathSeparator)
+  return binding.match(str, query, pathSeparator)
 }
 
 /*
@@ -388,7 +412,11 @@ export function wrap(str: string, query: string, options: IOptions = {}): string
     return []
   }
   parseOptions(options)
-  return binding.wrap(str, query, options.pathSeparator as string /* stringified by parseOption */)
+
+  const pathSeparator = options.pathSeparator as string /* stringified by parseOption */
+
+  Binding.validate_wrap(str, query, pathSeparator)
+  return binding.wrap(str, query, pathSeparator)
 }
 
 /*

--- a/src/binding/node.h
+++ b/src/binding/node.h
@@ -13,10 +13,6 @@ class ZadehNode : public Napi::ObjectWrap<ZadehNode> {
   public:
     Napi::Value Filter(const Napi::CallbackInfo &info) {
         auto res = Napi::Array::New(info.Env());
-        if (info.Length() != 4 || !info[0].IsString() || !info[1].IsNumber() || !info[2].IsBoolean() || !info[3].IsBoolean()) {
-            Napi::TypeError::New(info.Env(), "Invalid arguments for Filter").ThrowAsJavaScriptException();
-            return Napi::Boolean();
-        }
 
         const auto filter_indices = arrayFilterer.filter_indices(
           info[0].As<Napi::String>(),
@@ -32,25 +28,12 @@ class ZadehNode : public Napi::ObjectWrap<ZadehNode> {
 
 
     Napi::Value setArrayFiltererCandidates(const Napi::CallbackInfo &info) {
-        if (info.Length() != 1 || !info[0].IsArray()) {
-            Napi::TypeError::New(info.Env(), "Invalid arguments for setArrayFiltererCandidates").ThrowAsJavaScriptException();
-            return Napi::Boolean();
-        }
-
         arrayFilterer.set_candidates(info[0].As<Napi::Array>());
 
         return Napi::Boolean();
     }
 
     Napi::Value setTreeFiltererCandidates(const Napi::CallbackInfo &info) {
-        // parse arguments
-        if (info.Length() != 3
-            || !info[0].IsArray()
-            || !info[1].IsString() || !info[2].IsString()) {
-            Napi::TypeError::New(info.Env(), "Invalid arguments for setTreeFiltererCandidates").ThrowAsJavaScriptException();
-            return Napi::Boolean();
-        }
-
         // create Tree and set candidates
         treeFilterer.set_candidates(
           info[0].As<Napi::Array>(),
@@ -62,14 +45,6 @@ class ZadehNode : public Napi::ObjectWrap<ZadehNode> {
 
     /** (query: string, maxResults: number, usePathScoring: bool, useExtensionBonus: bool) */
     Napi::Value FilterTree(const Napi::CallbackInfo &info) {
-        // parse arguments
-        if (info.Length() != 4
-            || !info[0].IsString()
-            || !info[1].IsNumber() || !info[2].IsBoolean() || !info[3].IsBoolean()) {
-            Napi::TypeError::New(info.Env(), "Invalid arguments for FilterTree").ThrowAsJavaScriptException();
-            return Napi::Array::New(info.Env());
-        }
-
         const auto filter_indices = treeFilterer.filter_indices(
           info[0].As<Napi::String>(),
           info[1].As<Napi::Number>().Uint32Value(),
@@ -104,9 +79,6 @@ class ZadehNode : public Napi::ObjectWrap<ZadehNode> {
 
 
 Napi::Number score(const Napi::CallbackInfo &info) {
-    if (info.Length() != 4 || !info[0].IsString() || !info[1].IsString() || !info[2].IsBoolean() || !info[3].IsBoolean()) {
-        Napi::TypeError::New(info.Env(), "Invalid arguments for score").ThrowAsJavaScriptException();
-    }
     const std::string candidate = info[0].As<Napi::String>();
     const std::string query = info[1].As<Napi::String>();
     const bool usePathScoring = info[2].As<Napi::Boolean>();
@@ -119,17 +91,11 @@ Napi::Number score(const Napi::CallbackInfo &info) {
 
 Napi::Array match(const Napi::CallbackInfo &info) {
     auto res = Napi::Array::New(info.Env());
-    if (info.Length() != 3 || !info[0].IsString() || !info[1].IsString() || !info[2].IsString()) {
-        Napi::TypeError::New(info.Env(), "Invalid arguments for match").ThrowAsJavaScriptException();
-        return res;
-    }
     std::string candidate = info[0].As<Napi::String>();
     std::string query = info[1].As<Napi::String>();
     std::string pathSeparator = info[2].As<Napi::String>();
-    if (pathSeparator.size() != 1) {
-        Napi::TypeError::New(info.Env(), "Invalid arguments for match").ThrowAsJavaScriptException();
-        return res;
-    }
+    assert(pathSeparator.size() == 1);
+
     Options options(query, pathSeparator[0]);
     auto matches = matcher_match(candidate, query, options);
     for (uint32_t i = 0, len = matches.size(); i < len; i++) {
@@ -139,17 +105,11 @@ Napi::Array match(const Napi::CallbackInfo &info) {
 }
 
 Napi::String wrap(const Napi::CallbackInfo &info) {
-    if (info.Length() != 3 || !info[0].IsString() || !info[1].IsString() || !info[2].IsString()) {
-        Napi::TypeError::New(info.Env(), "Invalid arguments for wrap").ThrowAsJavaScriptException();
-        return Napi::String::New(info.Env(), "");
-    }
     std::string candidate = info[0].As<Napi::String>();
     std::string query = info[1].As<Napi::String>();
     std::string pathSeparator = info[2].As<Napi::String>();
-    if (pathSeparator.size() != 1) {
-        Napi::TypeError::New(info.Env(), "Invalid arguments for wrap").ThrowAsJavaScriptException();
-        return Napi::String::New(info.Env(), "");
-    }
+    assert(pathSeparator.size() == 1);
+
     Options options(query, pathSeparator[0]);
     std::string res;
     get_wrap(candidate, query, options, &res);


### PR DESCRIPTION
These validators are done using JavaScript, so it makes sense to do them on JavaScript anyways. It also simplifies C++ code.