### PR TITLE
feat: use string_view instead of string

### DIFF
--- a/src/binding/node_data_interface.h
+++ b/src/binding/node_data_interface.h
@@ -19,8 +19,8 @@ template <> Napi::Number init(const size_t value, const Napi::Env &env) {
 /** Napi::Array Data Interface */
 template <> Napi::Array init(const size_t len, const Napi::Env &env) { return Napi::Array::New(env, len); }
 
-template <> string_view get_at(const Napi::Array &candidates, const size_t ind) {
-  return string_view(candidates.Get(ind).ToString().Utf8Value());
+template <> string get_at(const Napi::Array &candidates, const size_t ind) {
+  return candidates.Get(ind).ToString().Utf8Value();
 }
 
 #ifndef ENV32BIT // only enable if size_t is not unint32_t
@@ -78,7 +78,7 @@ template <> Napi::Array copy(const Napi::Array &arr, const Napi::Env &env) {
   return arr_copy;
 }
 
-template <> CandidateString get_at(const Napi::Object &candidates, const string ind) {
+template <> string get_at(const Napi::Object &candidates, const string ind) {
   return candidates.Get(ind).ToString().Utf8Value();
 }
 

--- a/src/binding/node_data_interface.h
+++ b/src/binding/node_data_interface.h
@@ -19,8 +19,8 @@ template <> Napi::Number init(const size_t value, const Napi::Env &env) {
 /** Napi::Array Data Interface */
 template <> Napi::Array init(const size_t len, const Napi::Env &env) { return Napi::Array::New(env, len); }
 
-template <> string get_at(const Napi::Array &candidates, const size_t ind) {
-  return candidates.Get(ind).ToString().Utf8Value();
+template <> string_view get_at(const Napi::Array &candidates, const size_t ind) {
+  return string_view(candidates.Get(ind).ToString().Utf8Value());
 }
 
 #ifndef ENV32BIT // only enable if size_t is not unint32_t
@@ -36,7 +36,7 @@ template <> Napi::Object get_at(const Napi::Array &candidates, const size_t ind)
 template <> size_t get_size(const Napi::Array &candidates) { return candidates.Length(); }
 
 template <> void set_at(Napi::Array &candidates, CandidateString &&value, const size_t iCandidate) {
-  candidates.Set(iCandidate, move(value));
+  candidates.Set(iCandidate, move(string(value)));
 }
 
 template <> void set_at(Napi::Array &candidates, Napi::Number &&value, const uint32_t iCandidate) {
@@ -96,6 +96,10 @@ template <> void set_at(Napi::Object &candidates, size_t &&value, const string i
 
 template <> void set_at(Napi::Object &candidates, const string &value, const string index) {
   candidates.Set(index, value);
+}
+
+template <> void set_at(Napi::Object &candidates, const string_view &value, const string index) {
+  candidates.Set(index, string(value));
 }
 
 template <> void set_at(Napi::Object &candidates, const size_t &value, const string index) {

--- a/src/common.h
+++ b/src/common.h
@@ -34,8 +34,8 @@ public:
 using Element = SafeString;
 using CandidateString = SafeString;
 #else
-using Element = string;
-using CandidateString = string;
+using Element = string_view;
+using CandidateString = string_view;
 #endif
 
 using CandidateIndex = size_t;

--- a/src/common.h
+++ b/src/common.h
@@ -44,10 +44,10 @@ using Score = float;
 
 struct PreparedQuery {
   Element query;
-  Element query_lw;
-  Element core;
-  Element core_lw;
-  Element core_up;
+  string query_lw;
+  string core;
+  string core_lw;
+  string core_up;
   int depth = 0;
   Element ext;
   std::set<char> charCodes{};
@@ -55,13 +55,13 @@ struct PreparedQuery {
   explicit PreparedQuery(const Element &q, const char pathSeparator);
 };
 
-Element ToLower(const Element &s) {
+string ToLower(const Element &s) {
   auto snew = string(s.size(), ' '); // new string
   std::transform(s.begin(), s.end(), snew.begin(), ::tolower);
   return snew;
 }
 
-Element ToUpper(const Element &s) {
+string ToUpper(const Element &s) {
   auto snew = string(s.size(), ' '); // new string
   std::transform(s.begin(), s.end(), snew.begin(), ::toupper);
   return snew;

--- a/src/matcher.h
+++ b/src/matcher.h
@@ -246,7 +246,7 @@ void get_wrap(const CandidateString &string, const Element &query, const Options
   const auto tagClose = "</strong>"s;
 
   if (string == query) {
-    *out = tagOpen + string + tagClose;
+    *out = tagOpen + std::string(string) + tagClose;
     return;
   }
 

--- a/src/query.h
+++ b/src/query.h
@@ -10,7 +10,7 @@ namespace zadeh {
 // Optional chars
 // Those char improve the score if present, but will not block the match (score=0) if absent.
 
-Element coreChars(Element query) {
+Element coreChars(string query) {
   for (const auto ch : " _-:/\\") {
     query.erase(std::remove(query.begin(), query.end(), ch), query.end());
   }
@@ -33,7 +33,8 @@ std::set<char> getCharCodes(const Element &str) {
 }
 
 PreparedQuery::PreparedQuery(const Element &q, const char pathSeparator)
-    : query(q), query_lw(ToLower(q)), core(coreChars(q)), core_lw(ToLower(core)), core_up(ToUpper(core)) {
+    : query(q), query_lw(ToLower(q)), core(coreChars(string(q))), core_lw(ToLower(core)),
+      core_up(ToUpper(core)) {
   depth = countDir(query, query.size(), pathSeparator);
   ext = getExtension(query_lw);
   charCodes = getCharCodes(query_lw);

--- a/src/query.h
+++ b/src/query.h
@@ -10,7 +10,7 @@ namespace zadeh {
 // Optional chars
 // Those char improve the score if present, but will not block the match (score=0) if absent.
 
-Element coreChars(string query) {
+auto coreChars(string query) {
   for (const auto ch : " _-:/\\") {
     query.erase(std::remove(query.begin(), query.end(), ch), query.end());
   }


### PR DESCRIPTION
Fails because of 
```cpp
  CXX(target) Release/obj.target/zadeh/src/binding/node.o
In file included from ../src/binding/node.cc:3:
In file included from ../src/binding/./node.h:7:
In file included from ../src/binding/../zadeh.h:4:
../src/binding/.././common.h:61:10: warning: address of stack memory associated with local variable 'snew' returned [-Wreturn-stack-address]
  return snew;
         ^~~~
../src/binding/.././common.h:67:10: warning: address of stack memory associated with local variable 'snew' returned [-Wreturn-stack-address]
  return snew;
         ^~~~
In file included from ../src/binding/node.cc:3:
In file included from ../src/binding/./node.h:7:
In file included from ../src/binding/../zadeh.h:8:
In file included from ../src/binding/.././matcher.h:9:
../src/binding/../query.h:17:10: warning: address of stack memory associated with parameter 'query' returned [-Wreturn-stack-address]
  return query;
         ^~~~~
In file included from ../src/binding/node.cc:3:
In file included from ../src/binding/./node.h:8:
../src/binding/./node_data_interface.h:23:22: warning: returning address of local temporary object [-Wreturn-stack-address]
  return string_view(candidates.Get(ind).ToString().Utf8Value());
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/binding/./node_data_interface.h:82:10: warning: returning address of local temporary object [-Wreturn-stack-address]
  return candidates.Get(ind).ToString().Utf8Value();
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
5 warnings generated.
  SOLINK_MODULE(target) Release/obj.target/zadeh.node
  COPY Release/zadeh.node
```