### PR TITLE
bump prebuildify to work again after the atom domain sunset

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,5 +1,8 @@
 # Note: C++ standard is repeated in configurations multiple times for different configurations
 {
+  "variables" : {
+    "openssl_fips": "",
+  },
   "targets": [{
       "target_name": "zadeh",
       "sources": [

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "fuzzaldrin-plus": "^0.6.0",
     "jasmine": "^3.10.0",
     "parcel": "2.0.0",
-    "prebuildify": "^4.2.1",
+    "prebuildify": "^5",
     "prettier-config-atomic": "^3.0.1",
     "shx": "^0.3.3",
     "terser-config-atomic": "^0.1.1",


### PR DESCRIPTION
Hi - just bumping prebuildify so it doesn't try to download from the sunset `atom.io` domain anymore. Version 5.0.1 pulls in this needed commit https://github.com/prebuild/prebuildify/commit/eee641b3efd500c3802a25215b6d37e89ca4e53a 